### PR TITLE
release: v0.0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["orchestra", "metered-channel", "orchestra/proc-macro"]
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.0.4"
+version = "0.0.5"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paritytech/orchestra"

--- a/orchestra/Cargo.toml
+++ b/orchestra/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 async-trait = "0.1"
 thiserror = "1"
 metered = { package = "prioritized-metered-channel", version = "0.2.0", path = "../metered-channel" }
-orchestra-proc-macro = { version = "0.0.4", path = "./proc-macro" }
+orchestra-proc-macro = { version = "0.0.5", path = "./proc-macro" }
 futures-timer = "3.0.2"
 pin-project = "1.0"
 dyn-clonable = "0.9"


### PR DESCRIPTION
After the [infinite quest of remote signing is resolved](https://hachyderm.io/@drahnr/109760070036729749), let's release `v0.0.5`