### PR TITLE
Switch mettered inner to the async-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +96,15 @@ dependencies = [
  "once_cell",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -191,6 +211,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "expander"
@@ -498,6 +524,7 @@ name = "prioritized-metered-channel"
 version = "0.2.0"
 dependencies = [
  "assert_matches",
+ "async-channel",
  "coarsetime",
  "crossbeam-queue",
  "derive_more",

--- a/metered-channel/Cargo.toml
+++ b/metered-channel/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 futures = "0.3.21"
 futures-timer = "3.0.2"
+async-channel = "1.8.0"
 derive_more = "0.99"
 tracing = "0.1.35"
 thiserror = "1.0.31"

--- a/metered-channel/src/lib.rs
+++ b/metered-channel/src/lib.rs
@@ -134,7 +134,7 @@ fn measure_tof_check(nth: usize) -> bool {
 /// of a single type `T`
 
 #[derive(Debug)]
-pub enum MaybeTimeOfFlight<T> {
+pub enum MaybeTimeOfFlight<T: Sized> {
 	Bare(T),
 	WithTimeOfFlight(T, CoarseInstant),
 }

--- a/metered-channel/src/tests.rs
+++ b/metered-channel/src/tests.rs
@@ -130,7 +130,7 @@ fn failed_send_does_not_inc_sent() {
 
 #[test]
 fn blocked_send_is_metered() {
-	let (mut bounded_sender, mut bounded_receiver) = channel::<Msg>(1);
+	let (mut bounded_sender, mut bounded_receiver) = channel::<Msg>(2);
 
 	block_on(async move {
 		assert!(bounded_sender.send(Msg::default()).await.is_ok());

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -226,7 +226,9 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 								#support_crate ::OrchestraError::SubsystemStalled(instance.name, "message", ::std::any::type_name::<M>())
 							))
 						}
-						Some(res) => res.map_err(Into::into),
+						Some(res) => res.map_err(|e| #error_ty :: from(
+								#support_crate ::OrchestraError::QueueError(e)
+							)),
 					}
 				} else {
 					Ok(())
@@ -247,7 +249,9 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 							))
 						}
 						Some(res) => {
-							let res = res.map_err(Into::into);
+							let res = res.map_err(|e| #error_ty :: from(
+								#support_crate ::OrchestraError::QueueError(e)
+							));
 							if res.is_ok() {
 								instance.signals_received += 1;
 							}

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -275,7 +275,7 @@ pub enum OrchestraError {
 	NotifyCancellation(#[from] oneshot::Canceled),
 
 	#[error(transparent)]
-	QueueError(#[from] mpsc::SendError),
+	QueueError(#[from] metered::SendError),
 
 	#[error("Failed to spawn task {0}")]
 	TaskSpawn(&'static str),


### PR DESCRIPTION
This PR provides the ad-hoc replacement for the inner bounded channel from `futures::mpsc` to `async_channel::bounded`. The former channel is based on the shared memory ring that provides benefits in terms of latency and throughput. This PR also removes the requirement for the consumers to implement `From<mpsc::SendError>` as now it is returned as `OrchestraError::QueueError` transparently. There should be no API breaking to my best knowledge.