### PR TITLE
Feature gating subsystems via `#[cfg]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ declarative.
         #[subsystem(MsgA, sends: [MsgB])]
         sub_a: AwesomeSubSysA,
 
+        #[cfg(any(feature = "feature1", feature = "feature2"))]
         #[subsystem(MsgB, sends: [MsgA])]
         sub_b: AwesomeSubSysB,
     }
@@ -32,6 +33,7 @@ error type, if not provided a builtin one is used. Note that this is the one err
 into the orchestra, without participating in the subsystem pattern.
 * `signal=` defines a signal type to be used for the orchestra. This is a shared "tick" or "clock" for all subsystems.
 * `gen=` defines a wrapping `enum` type that is used to wrap all messages that can be consumed by _any_ subsystem.
+* Features can be feature gated by `#[cfg(feature = "feature")]` attribute macro expressions. Currently supported are `any`, `all`, `not` and `feature`.
 
 ```rust
     /// Execution context, always required.

--- a/orchestra/proc-macro/Cargo.toml
+++ b/orchestra/proc-macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = { version = "1.0.47", features = ["span-locations"] }
 proc-macro-crate = "1.1.3"
 expander = { version = "0.0.6", default-features = false }
 petgraph = "0.6.0"
-itertools = { version = "0.10.3" }
+itertools = "0.10.3"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -38,7 +38,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	let subsystem_ctx_name = format_ident!("{}SubsystemContext", orchestra_name);
 	let feature_powerset_cfgs = &info.feature_gated_subsystem_sets();
 
-	let mut ts = quote! {};
+	let mut ts = proc_macro2::TokenStream::new();
 
 	// In this loop we generate items that are required for each config set separately
 	for cfg_set in feature_powerset_cfgs.into_iter() {

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -31,96 +31,208 @@ fn recollect_without_idx<T: Clone>(x: &[T], idx: usize) -> Vec<T> {
 /// Elements tagged with `wip` are not covered here.
 pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	let orchestra_name = info.orchestra_name.clone();
+
 	let builder = format_ident!("{}Builder", orchestra_name);
 	let handle = format_ident!("{}Handle", orchestra_name);
 	let connector = format_ident!("{}Connector", orchestra_name);
 	let subsystem_ctx_name = format_ident!("{}SubsystemContext", orchestra_name);
-
 	let feature_powerset_cfgs = &info.feature_gates_complete();
 
 	let mut ts = quote! {};
+
+	// In this loop we generate items that are reguired for each config set separately
 	for cfg_set in feature_powerset_cfgs.into_iter() {
-		//TODO insert everything here
-
-		let cfg_guard = cfg_set.guard.clone();
-		let subsystem_name = &info.subsystem_names_without_wip2(&cfg_set.enabled_subsystems);
-		let subsystem_generics = &info.subsystem_generic_types2(&cfg_set.enabled_subsystems);
-		let consumes = &info.consumes_without_wip2(&cfg_set.enabled_subsystems);
-		let channel_name = &info.channel_names_without_wip2(None, &cfg_set.enabled_subsystems);
-		let channel_name_unbounded =
-			&info.channel_names_without_wip2("_unbounded", &cfg_set.enabled_subsystems);
-		let message_channel_capacity = &info.message_channel_capacities_without_wip2(
-			info.message_channel_capacity,
-			&cfg_set.enabled_subsystems,
+		let builder_items_for_config = impl_feature_guarded_items(
+			info,
+			cfg_set,
+			&builder,
+			&subsystem_ctx_name,
+			&connector,
+			&orchestra_name,
+			&handle,
 		);
-		let signal_channel_capacity = &info.signal_channel_capacities_without_wip2(
-			info.signal_channel_capacity,
-			&cfg_set.enabled_subsystems,
-		);
+		ts.extend(builder_items_for_config);
+	}
 
-		let channel_name_tx = &info.channel_names_without_wip2("_tx", &cfg_set.enabled_subsystems);
-		let channel_name_unbounded_tx =
-			&info.channel_names_without_wip2("_unbounded_tx", &cfg_set.enabled_subsystems);
+	let event = &info.extern_event_ty;
+	let support_crate = info.support_crate_name();
 
-		let channel_name_rx = &info.channel_names_without_wip2("_rx", &cfg_set.enabled_subsystems);
-		let channel_name_unbounded_rx =
-			&info.channel_names_without_wip2("_unbounded_rx", &cfg_set.enabled_subsystems);
+	ts.extend(quote! {
+		/// Handle for an orchestra.
+		pub type #handle = #support_crate ::metered::MeteredSender< #event >;
 
-		let baggage_name = &info.baggage_names();
-		let baggage_generic_ty = &info.baggage_generic_types();
+		/// External connector.
+		pub struct #connector {
+			/// Publicly accessible handle, to be used for setting up
+			/// components that are _not_ subsystems but access is needed
+			/// due to other limitations.
+			///
+			/// For subsystems, use the `_with` variants of the builder.
+			handle: #handle,
+			/// The side consumed by the `spawned` side of the orchestra pattern.
+			consumer: #support_crate ::metered::MeteredReceiver < #event >,
+		}
 
-		// State generics that are used to encode each field's status (Init/Missing)
-		let baggage_passthrough_state_generics = baggage_name
-			.iter()
-			.enumerate()
-			.map(|(idx, _)| format_ident!("InitStateBaggage{}", idx))
-			.collect::<Vec<_>>();
-		let subsystem_passthrough_state_generics = subsystem_name
-			.iter()
-			.enumerate()
-			.map(|(idx, _)| format_ident!("InitStateSubsystem{}", idx))
-			.collect::<Vec<_>>();
+		impl #connector {
+			/// Obtain access to the orchestra handle.
+			pub fn as_handle_mut(&mut self) -> &mut #handle {
+				&mut self.handle
+			}
+			/// Obtain access to the orchestra handle.
+			pub fn as_handle(&self) -> &#handle {
+				&self.handle
+			}
+			/// Obtain a clone of the handle.
+			pub fn handle(&self) -> #handle {
+				self.handle.clone()
+			}
 
-		let error_ty = &info.extern_error_ty;
+			/// Create a new connector with non-default event channel capacity.
+			pub fn with_event_capacity(event_channel_capacity: usize) -> Self {
+				let (events_tx, events_rx) = #support_crate ::metered::channel::<
+					#event
+					>(event_channel_capacity);
 
-		let support_crate = info.support_crate_name();
-
-		let blocking = &cfg_set
-			.enabled_subsystems
-			.iter()
-			.map(|x| {
-				if x.blocking {
-					quote! { Blocking }
-				} else {
-					quote! { Regular }
+				Self {
+					handle: events_tx,
+					consumer: events_rx,
 				}
+			}
+		}
+
+		impl ::std::default::Default for #connector {
+			fn default() -> Self {
+				Self::with_event_capacity(SIGNAL_CHANNEL_CAPACITY)
+			}
+		}
+	});
+
+	let error_ty = &info.extern_error_ty;
+	ts.extend(quote! {
+			/// Convenience alias.
+			type SubsystemInitFn<T> = Box<dyn FnOnce(#handle) -> ::std::result::Result<T, #error_ty> + Send + 'static>;
+
+			/// Type for the initialized field of the orchestra builder
+			pub enum Init<T> {
+				/// Defer initialization to a point where the `handle` is available.
+				Fn(SubsystemInitFn<T>),
+				/// Directly initialize the subsystem with the given subsystem type `T`.
+				/// Also used for baggage fields
+				Value(T),
+			}
+			/// Type marker for the uninitialized field of the orchestra builder.
+			/// `PhantomData` is used for type hinting when creating uninitialized
+			/// builder, e.g. to avoid specifying the generics when instantiating
+			/// the `FooBuilder` when calling `Foo::builder()`
+			#[derive(Debug)]
+			pub struct Missing<T>(::core::marker::PhantomData<T>);
+
+			/// Trait used to mark fields status in a builder
+			trait OrchestraFieldState<T> {}
+
+			impl<T> OrchestraFieldState<T> for Init<T> {}
+			impl<T> OrchestraFieldState<T> for Missing<T> {}
+
+			impl<T> ::std::default::Default for Missing<T> {
+				fn default() -> Self {
+					Missing::<T>(::core::marker::PhantomData::<T>::default())
+				}
+			}
+	});
+	ts.extend(impl_task_kind(info));
+	ts
+}
+
+pub(crate) fn impl_feature_guarded_items(
+	info: &OrchestraInfo,
+	cfg_set: &SubsystemConfigSet,
+	builder: &Ident,
+	subsystem_ctx_name: &Ident,
+	connector: &Ident,
+	orchestra_name: &Ident,
+	handle: &Ident,
+) -> proc_macro2::TokenStream {
+	let mut ts = quote! {};
+
+	let cfg_guard = cfg_set.guard.clone();
+	let subsystem_name = &info.subsystem_names_without_wip2(&cfg_set.enabled_subsystems);
+	let subsystem_generics = &info.subsystem_generic_types2(&cfg_set.enabled_subsystems);
+	let consumes = &info.consumes_without_wip2(&cfg_set.enabled_subsystems);
+	let channel_name = &info.channel_names_without_wip2(None, &cfg_set.enabled_subsystems);
+	let channel_name_unbounded =
+		&info.channel_names_without_wip2("_unbounded", &cfg_set.enabled_subsystems);
+	let message_channel_capacity = &info.message_channel_capacities_without_wip2(
+		info.message_channel_capacity,
+		&cfg_set.enabled_subsystems,
+	);
+	let signal_channel_capacity = &info.signal_channel_capacities_without_wip2(
+		info.signal_channel_capacity,
+		&cfg_set.enabled_subsystems,
+	);
+
+	let channel_name_tx = &info.channel_names_without_wip2("_tx", &cfg_set.enabled_subsystems);
+	let channel_name_unbounded_tx =
+		&info.channel_names_without_wip2("_unbounded_tx", &cfg_set.enabled_subsystems);
+
+	let channel_name_rx = &info.channel_names_without_wip2("_rx", &cfg_set.enabled_subsystems);
+	let channel_name_unbounded_rx =
+		&info.channel_names_without_wip2("_unbounded_rx", &cfg_set.enabled_subsystems);
+
+	let baggage_name = &info.baggage_names();
+	let baggage_generic_ty = &info.baggage_generic_types();
+
+	// State generics that are used to encode each field's status (Init/Missing)
+	let baggage_passthrough_state_generics = baggage_name
+		.iter()
+		.enumerate()
+		.map(|(idx, _)| format_ident!("InitStateBaggage{}", idx))
+		.collect::<Vec<_>>();
+	let subsystem_passthrough_state_generics = subsystem_name
+		.iter()
+		.enumerate()
+		.map(|(idx, _)| format_ident!("InitStateSubsystem{}", idx))
+		.collect::<Vec<_>>();
+
+	let error_ty = &info.extern_error_ty;
+
+	let support_crate = info.support_crate_name();
+
+	let blocking = &cfg_set
+		.enabled_subsystems
+		.iter()
+		.map(|x| {
+			if x.blocking {
+				quote! { Blocking }
+			} else {
+				quote! { Regular }
+			}
+		})
+		.collect::<Vec<_>>();
+
+	// Helpers to use within quote! macros
+	let spawner_where_clause: syn::TypeParam = parse_quote! {
+			S: #support_crate ::Spawner
+	};
+
+	// Field names and real types
+	let field_name = subsystem_name.iter().chain(baggage_name.iter()).collect::<Vec<_>>();
+	let field_type = subsystem_generics
+		.iter()
+		.map(|ident| {
+			syn::Type::Path(TypePath {
+				qself: None,
+				path: Path::from(PathSegment::from(ident.clone())),
 			})
-			.collect::<Vec<_>>();
+		})
+		.chain(info.baggage().iter().map(|bag| bag.field_ty.clone()))
+		.collect::<Vec<_>>();
 
-		// Helpers to use within quote! macros
-		let spawner_where_clause: syn::TypeParam = parse_quote! {
-				S: #support_crate ::Spawner
-		};
+	// Setters logic
 
-		// Field names and real types
-		let field_name = subsystem_name.iter().chain(baggage_name.iter()).collect::<Vec<_>>();
-		let field_type = subsystem_generics
-			.iter()
-			.map(|ident| {
-				syn::Type::Path(TypePath {
-					qself: None,
-					path: Path::from(PathSegment::from(ident.clone())),
-				})
-			})
-			.chain(info.baggage().iter().map(|bag| bag.field_ty.clone()))
-			.collect::<Vec<_>>();
-
-		// Setters logic
-
-		// For each setter we need to leave the remaining fields untouched and
-		// remove the field that we are fixing in this setter
-		// For subsystems `*_with` and `replace_*` setters are needed.
-		let subsystem_specific_setters =
+	// For each setter we need to leave the remaining fields untouched and
+	// remove the field that we are fixing in this setter
+	// For subsystems `*_with` and `replace_*` setters are needed.
+	let subsystem_specific_setters =
 		cfg_set.enabled_subsystems.iter().filter(|ssf| !ssf.wip).enumerate().map(|(idx, ssf)| {
 			let field_name = &ssf.name;
 			let field_type = &ssf.generic;
@@ -259,8 +371,8 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 			}
 		});
 
-		// Produce setters for all baggage fields as well
-		let baggage_specific_setters = info.baggage().iter().enumerate().map(|(idx, bag_field)| {
+	// Produce setters for all baggage fields as well
+	let baggage_specific_setters = info.baggage().iter().enumerate().map(|(idx, bag_field)| {
 		// Baggage fields follow subsystems
 		let fname = &bag_field.field_name;
 		let field_type = &bag_field.field_ty;
@@ -330,53 +442,53 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		}
 	});
 
-		let initialized_builder = format_ident!("Initialized{}", builder);
-		// The direct generics as expected by the `Orchestra<_,_,..>`, without states
-		let initialized_builder_generics = quote! {
-			S, #( #baggage_generic_ty, )* #( #subsystem_generics, )*
-		};
+	let initialized_builder = format_ident!("Initialized{}", builder);
+	// The direct generics as expected by the `Orchestra<_,_,..>`, without states
+	let initialized_builder_generics = quote! {
+		S, #( #baggage_generic_ty, )* #( #subsystem_generics, )*
+	};
 
-		let builder_where_clause = cfg_set
-			.enabled_subsystems
-			.iter()
-			.map(|ssf| {
-				let field_type = &ssf.generic;
-				let consumes = &ssf.message_to_consume();
-				let subsystem_sender_trait = format_ident!("{}SenderTrait", ssf.generic);
-				let subsystem_ctx_trait = format_ident!("{}ContextTrait", ssf.generic);
-				quote! {
-					#field_type:
-						#support_crate::Subsystem< #subsystem_ctx_name < #consumes>, #error_ty>,
-					<#subsystem_ctx_name< #consumes > as #subsystem_ctx_trait>::Sender:
-						#subsystem_sender_trait,
-					#subsystem_ctx_name< #consumes >:
-						#subsystem_ctx_trait,
-				}
-			})
-			.fold(TokenStream::new(), |mut ts, addendum| {
-				ts.extend(addendum);
-				ts
-			});
-
-		ts.extend(quote! {
-			#cfg_guard
-			impl<S #(, #baggage_generic_ty )*> #orchestra_name <S #(, #baggage_generic_ty)*>
-			where
-				#spawner_where_clause,
-			{
-				/// Create a new orchestra utilizing the builder.
-				#[allow(clippy::type_complexity)]
-				pub fn builder< #( #subsystem_generics),* >() ->
-					#builder<Missing<S> #(, Missing< #field_type > )* >
-				where
-					#builder_where_clause
-				{
-					#builder :: new()
-				}
+	let builder_where_clause = cfg_set
+		.enabled_subsystems
+		.iter()
+		.map(|ssf| {
+			let field_type = &ssf.generic;
+			let consumes = &ssf.message_to_consume();
+			let subsystem_sender_trait = format_ident!("{}SenderTrait", ssf.generic);
+			let subsystem_ctx_trait = format_ident!("{}ContextTrait", ssf.generic);
+			quote! {
+				#field_type:
+					#support_crate::Subsystem< #subsystem_ctx_name < #consumes>, #error_ty>,
+				<#subsystem_ctx_name< #consumes > as #subsystem_ctx_trait>::Sender:
+					#subsystem_sender_trait,
+				#subsystem_ctx_name< #consumes >:
+					#subsystem_ctx_trait,
 			}
+		})
+		.fold(TokenStream::new(), |mut ts, addendum| {
+			ts.extend(addendum);
+			ts
 		});
 
-		ts.extend(quote!{
+	ts.extend(quote! {
+		#cfg_guard
+		impl<S #(, #baggage_generic_ty )*> #orchestra_name <S #(, #baggage_generic_ty)*>
+		where
+			#spawner_where_clause,
+		{
+			/// Create a new orchestra utilizing the builder.
+			#[allow(clippy::type_complexity)]
+			pub fn builder< #( #subsystem_generics),* >() ->
+				#builder<Missing<S> #(, Missing< #field_type > )* >
+			where
+				#builder_where_clause
+			{
+				#builder :: new()
+			}
+		}
+	});
+
+	ts.extend(quote!{
 		/// Builder pattern to create compile time safe construction path.
 		#[allow(clippy::type_complexity)]
 		#cfg_guard
@@ -397,36 +509,36 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		}
 	});
 
-		ts.extend(quote! {
-			#[allow(clippy::type_complexity)]
-			#cfg_guard
-			impl<#initialized_builder_generics> #builder<Missing<S>, #( Missing<#field_type>, )*>
-			{
-				/// Create a new builder pattern, with all fields being uninitialized.
-				fn new() -> Self {
-					// explicitly assure the required traits are implemented
-					fn trait_from_must_be_implemented<E>()
-					where
-						E: ::std::error::Error + Send + Sync + 'static + From<#support_crate ::OrchestraError>
-					{}
+	ts.extend(quote! {
+		#[allow(clippy::type_complexity)]
+		#cfg_guard
+		impl<#initialized_builder_generics> #builder<Missing<S>, #( Missing<#field_type>, )*>
+		{
+			/// Create a new builder pattern, with all fields being uninitialized.
+			fn new() -> Self {
+				// explicitly assure the required traits are implemented
+				fn trait_from_must_be_implemented<E>()
+				where
+					E: ::std::error::Error + Send + Sync + 'static + From<#support_crate ::OrchestraError>
+				{}
 
-					trait_from_must_be_implemented::< #error_ty >();
+				trait_from_must_be_implemented::< #error_ty >();
 
-					Self {
-						#(
-							#field_name: Missing::<#field_type>::default(),
-						)*
-						spawner: Missing::<S>::default(),
+				Self {
+					#(
+						#field_name: Missing::<#field_type>::default(),
+					)*
+					spawner: Missing::<S>::default(),
 
-						channel_capacity: None,
-						signal_capacity: None,
-					}
+					channel_capacity: None,
+					signal_capacity: None,
 				}
 			}
-		});
+		}
+	});
 
-		// Spawner setter
-		ts.extend(quote!{
+	// Spawner setter
+	ts.extend(quote!{
 		#[allow(clippy::type_complexity)]
 		#cfg_guard
 		impl<S, #( #subsystem_passthrough_state_generics, )* #( #baggage_passthrough_state_generics, )*>
@@ -454,8 +566,8 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		}
 	});
 
-		// message and signal channel capacity
-		ts.extend(quote! {
+	// message and signal channel capacity
+	ts.extend(quote! {
 		#[allow(clippy::type_complexity)]
 		#cfg_guard
 		impl<S, #( #subsystem_passthrough_state_generics, )* #( #baggage_passthrough_state_generics, )*>
@@ -483,13 +595,13 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		}
 	});
 
-		// Create the string literals for spawn.
-		let subsystem_name_str_literal = subsystem_name
-			.iter()
-			.map(|ident| proc_macro2::Literal::string(ident.to_string().replace("_", "-").as_str()))
-			.collect::<Vec<_>>();
+	// Create the string literals for spawn.
+	let subsystem_name_str_literal = subsystem_name
+		.iter()
+		.map(|ident| proc_macro2::Literal::string(ident.to_string().replace("_", "-").as_str()))
+		.collect::<Vec<_>>();
 
-		ts.extend(quote! {
+	ts.extend(quote! {
 		/// Type used to represent a builder where all fields are initialized and the orchestra could be constructed.
 		#cfg_guard
 		pub type #initialized_builder<#initialized_builder_generics> = #builder<Init<S>, #( Init<#field_type>, )*>;
@@ -627,95 +739,8 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		}
 	});
 
-		ts.extend(baggage_specific_setters);
-		ts.extend(subsystem_specific_setters);
-	}
-
-	let event = &info.extern_event_ty;
-	let support_crate = info.support_crate_name();
-	ts.extend(quote! {
-		/// Handle for an orchestra.
-		pub type #handle = #support_crate ::metered::MeteredSender< #event >;
-
-		/// External connector.
-		pub struct #connector {
-			/// Publicly accessible handle, to be used for setting up
-			/// components that are _not_ subsystems but access is needed
-			/// due to other limitations.
-			///
-			/// For subsystems, use the `_with` variants of the builder.
-			handle: #handle,
-			/// The side consumed by the `spawned` side of the orchestra pattern.
-			consumer: #support_crate ::metered::MeteredReceiver < #event >,
-		}
-
-		impl #connector {
-			/// Obtain access to the orchestra handle.
-			pub fn as_handle_mut(&mut self) -> &mut #handle {
-				&mut self.handle
-			}
-			/// Obtain access to the orchestra handle.
-			pub fn as_handle(&self) -> &#handle {
-				&self.handle
-			}
-			/// Obtain a clone of the handle.
-			pub fn handle(&self) -> #handle {
-				self.handle.clone()
-			}
-
-			/// Create a new connector with non-default event channel capacity.
-			pub fn with_event_capacity(event_channel_capacity: usize) -> Self {
-				let (events_tx, events_rx) = #support_crate ::metered::channel::<
-					#event
-					>(event_channel_capacity);
-
-				Self {
-					handle: events_tx,
-					consumer: events_rx,
-				}
-			}
-		}
-
-		impl ::std::default::Default for #connector {
-			fn default() -> Self {
-				Self::with_event_capacity(SIGNAL_CHANNEL_CAPACITY)
-			}
-		}
-	});
-
-	let error_ty = &info.extern_error_ty;
-	ts.extend(quote! {
-			/// Convenience alias.
-			type SubsystemInitFn<T> = Box<dyn FnOnce(#handle) -> ::std::result::Result<T, #error_ty> + Send + 'static>;
-
-			/// Type for the initialized field of the orchestra builder
-			pub enum Init<T> {
-				/// Defer initialization to a point where the `handle` is available.
-				Fn(SubsystemInitFn<T>),
-				/// Directly initialize the subsystem with the given subsystem type `T`.
-				/// Also used for baggage fields
-				Value(T),
-			}
-			/// Type marker for the uninitialized field of the orchestra builder.
-			/// `PhantomData` is used for type hinting when creating uninitialized
-			/// builder, e.g. to avoid specifying the generics when instantiating
-			/// the `FooBuilder` when calling `Foo::builder()`
-			#[derive(Debug)]
-			pub struct Missing<T>(::core::marker::PhantomData<T>);
-
-			/// Trait used to mark fields status in a builder
-			trait OrchestraFieldState<T> {}
-
-			impl<T> OrchestraFieldState<T> for Init<T> {}
-			impl<T> OrchestraFieldState<T> for Missing<T> {}
-
-			impl<T> ::std::default::Default for Missing<T> {
-				fn default() -> Self {
-					Missing::<T>(::core::marker::PhantomData::<T>::default())
-				}
-			}
-	});
-	ts.extend(impl_task_kind(info));
+	ts.extend(baggage_specific_setters);
+	ts.extend(subsystem_specific_setters);
 	ts
 }
 

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -42,7 +42,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 
 	// In this loop we generate items that are required for each config set separately
 	for cfg_set in feature_powerset_cfgs.into_iter() {
-		let builder_items_for_config = impl_feature_guarded_items(
+		let builder_items_for_config = impl_feature_gated_items(
 			info,
 			cfg_set,
 			&builder,
@@ -143,7 +143,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	ts
 }
 
-pub(crate) fn impl_feature_guarded_items(
+pub(crate) fn impl_feature_gated_items(
 	info: &OrchestraInfo,
 	cfg_set: &SubsystemConfigSet,
 	builder: &Ident,

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -117,6 +117,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 			// that since we always move from `Init<#field_type>` to `Init<NEW>`.
 			let impl_subsystem_state_generics = recollect_without_idx(&subsystem_passthrough_state_generics[..], idx);
 
+			let feature_guard =	ssf.feature_guard.clone().map_or(quote! {}, |fg| quote! { #[cfg(feature = #fg)] });
 			let field_name_with = format_ident!("{}_with", field_name);
 			let field_name_replace = format_ident!("replace_{}", field_name);
 
@@ -150,6 +151,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 
 			// Create the field init `fn`
 			quote! {
+				#feature_guard
 				impl <InitStateSpawner, #field_type, #( #impl_subsystem_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 				#builder <InitStateSpawner, #( #current_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 				where
@@ -163,6 +165,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 						#builder {
 							#field_name: Init::< #field_type >::Value(var),
 							#(
+								#feature_guards
 								#to_keep_subsystem_name: self. #to_keep_subsystem_name,
 							)*
 							#(
@@ -189,6 +192,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 						#builder {
 							#field_name: boxed_func,
 							#(
+								#feature_guards
 								#to_keep_subsystem_name: self. #to_keep_subsystem_name,
 							)*
 							#(
@@ -204,6 +208,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 				}
 
 				#[allow(clippy::type_complexity)]
+				#feature_guard
 				impl <InitStateSpawner, #field_type, #( #impl_subsystem_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 				#builder <InitStateSpawner, #( #post_setter_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 				where
@@ -230,6 +235,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 						#builder {
 							#field_name: replacement,
 							#(
+								#feature_guards
 								#to_keep_subsystem_name: self. #to_keep_subsystem_name,
 							)*
 							#(

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -36,7 +36,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	let handle = format_ident!("{}Handle", orchestra_name);
 	let connector = format_ident!("{}Connector", orchestra_name);
 	let subsystem_ctx_name = format_ident!("{}SubsystemContext", orchestra_name);
-	let feature_powerset_cfgs = &info.feature_gates_complete();
+	let feature_powerset_cfgs = &info.feature_gated_subsystem_sets();
 
 	let mut ts = quote! {};
 
@@ -154,7 +154,7 @@ pub(crate) fn impl_feature_guarded_items(
 ) -> proc_macro2::TokenStream {
 	let mut ts = quote! {};
 
-	let cfg_guard = &cfg_set.guard.clone();
+	let cfg_guard = &cfg_set.feature_gate.clone();
 	let subsystem_name = &cfg_set.subsystem_names_without_wip();
 	let subsystem_generics = &cfg_set.subsystem_generic_types();
 	let consumes = &cfg_set.consumes_without_wip();

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -154,29 +154,22 @@ pub(crate) fn impl_feature_guarded_items(
 ) -> proc_macro2::TokenStream {
 	let mut ts = quote! {};
 
-	let cfg_guard = cfg_set.guard.clone();
-	let subsystem_name = &info.subsystem_names_without_wip2(&cfg_set.enabled_subsystems);
-	let subsystem_generics = &info.subsystem_generic_types2(&cfg_set.enabled_subsystems);
-	let consumes = &info.consumes_without_wip2(&cfg_set.enabled_subsystems);
-	let channel_name = &info.channel_names_without_wip2(None, &cfg_set.enabled_subsystems);
-	let channel_name_unbounded =
-		&info.channel_names_without_wip2("_unbounded", &cfg_set.enabled_subsystems);
-	let message_channel_capacity = &info.message_channel_capacities_without_wip2(
-		info.message_channel_capacity,
-		&cfg_set.enabled_subsystems,
-	);
-	let signal_channel_capacity = &info.signal_channel_capacities_without_wip2(
-		info.signal_channel_capacity,
-		&cfg_set.enabled_subsystems,
-	);
+	let cfg_guard = &cfg_set.guard.clone();
+	let subsystem_name = &cfg_set.subsystem_names_without_wip();
+	let subsystem_generics = &cfg_set.subsystem_generic_types();
+	let consumes = &cfg_set.consumes_without_wip();
+	let channel_name = &cfg_set.channel_names_without_wip(None);
+	let channel_name_unbounded = &cfg_set.channel_names_without_wip("_unbounded");
+	let message_channel_capacity =
+		&cfg_set.message_channel_capacities_without_wip(info.message_channel_capacity);
+	let signal_channel_capacity =
+		&cfg_set.signal_channel_capacities_without_wip(info.signal_channel_capacity);
 
-	let channel_name_tx = &info.channel_names_without_wip2("_tx", &cfg_set.enabled_subsystems);
-	let channel_name_unbounded_tx =
-		&info.channel_names_without_wip2("_unbounded_tx", &cfg_set.enabled_subsystems);
+	let channel_name_tx = &cfg_set.channel_names_without_wip("_tx");
+	let channel_name_unbounded_tx = &cfg_set.channel_names_without_wip("_unbounded_tx");
 
-	let channel_name_rx = &info.channel_names_without_wip2("_rx", &cfg_set.enabled_subsystems);
-	let channel_name_unbounded_rx =
-		&info.channel_names_without_wip2("_unbounded_rx", &cfg_set.enabled_subsystems);
+	let channel_name_rx = &cfg_set.channel_names_without_wip("_rx");
+	let channel_name_unbounded_rx = &info.channel_names_without_wip("_unbounded_rx");
 
 	let baggage_name = &info.baggage_names();
 	let baggage_generic_ty = &info.baggage_generic_types();

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -36,9 +36,16 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	let connector = format_ident!("{}Connector", orchestra_name);
 	let subsystem_ctx_name = format_ident!("{}SubsystemContext", orchestra_name);
 
+	let feature_powerset_cfgs = &info.feature_gates_complete();
+	let powerset_cfgs: Vec<TokenStream> =
+		feature_powerset_cfgs.iter().map(|set| set.guard.clone()).collect();
+
+	for cfg_set in feature_powerset_cfgs {
+		//TODO insert everything here
+	}
+
 	let subsystem_name = &info.subsystem_names_without_wip();
 	let subsystem_generics = &info.subsystem_generic_types();
-
 	let consumes = &info.consumes_without_wip();
 	let channel_name = &info.channel_names_without_wip(None);
 	let channel_name_unbounded = &info.channel_names_without_wip("_unbounded");
@@ -67,8 +74,6 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		.enumerate()
 		.map(|(idx, _)| format_ident!("InitStateSubsystem{}", idx))
 		.collect::<Vec<_>>();
-
-	let feature_powerset_cfgs = &info.feature_gates_complete();
 
 	let error_ty = &info.extern_error_ty;
 
@@ -351,7 +356,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 	let mut ts = quote! {
 
 		#(
-			#feature_powerset_cfgs
+			#powerset_cfgs
 			struct Bla;
 		)*
 

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -154,7 +154,7 @@ pub(crate) fn impl_feature_guarded_items(
 ) -> proc_macro2::TokenStream {
 	let mut ts = quote! {};
 
-	let cfg_guard = &cfg_set.feature_gate.clone();
+	let cfg_guard = &cfg_set.feature_gate;
 	let subsystem_name = &cfg_set.subsystem_names_without_wip();
 	let subsystem_generics = &cfg_set.subsystem_generic_types();
 	let consumes = &cfg_set.consumes_without_wip();

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -665,7 +665,6 @@ pub(crate) fn impl_feature_guarded_items(
 					>::new();
 
 				#(
-					let #subsystem_name: OrchestratedSubsystem< #consumes > = {
 					let #subsystem_name = match self. #subsystem_name {
 						Init::Fn(func) => func(events_tx.clone())?,
 						Init::Value(val) => val,
@@ -689,7 +688,7 @@ pub(crate) fn impl_feature_guarded_items(
 						#subsystem_name_str_literal
 					);
 
-						spawn::<_,_, #blocking, _, _, _>(
+					let #subsystem_name: OrchestratedSubsystem< #consumes > =	spawn::<_,_, #blocking, _, _, _>(
 							&mut spawner,
 							#channel_name_tx,
 							signal_tx,
@@ -698,8 +697,7 @@ pub(crate) fn impl_feature_guarded_items(
 							#subsystem_name,
 							#subsystem_name_str_literal,
 							&mut running_subsystems,
-						)?
-					};
+						)?;
 				)*
 
 				// silence a clippy warning for the last instantiation

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -40,7 +40,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 
 	let mut ts = quote! {};
 
-	// In this loop we generate items that are reguired for each config set separately
+	// In this loop we generate items that are required for each config set separately
 	for cfg_set in feature_powerset_cfgs.into_iter() {
 		let builder_items_for_config = impl_feature_guarded_items(
 			info,

--- a/orchestra/proc-macro/src/impl_channels_out.rs
+++ b/orchestra/proc-macro/src/impl_channels_out.rs
@@ -30,7 +30,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 	let consumes_variant = &info.variant_names_without_wip();
 	let unconsumes_variant = &info.variant_names_only_wip();
 
-	let feature_guards = info.feature_gates();
+	let feature_gates = info.feature_gates();
 	let support_crate = info.support_crate_name();
 
 	let ts = quote! {
@@ -41,7 +41,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 		pub struct ChannelsOut {
 			#(
 				/// Bounded channel sender, connected to a subsystem.
-				#feature_guards
+				#feature_gates
 				pub #channel_name:
 					#support_crate ::metered::MeteredSender<
 						MessagePacket< #consumes >
@@ -50,7 +50,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 
 			#(
 				/// Unbounded channel sender, connected to a subsystem.
-				#feature_guards
+				#feature_gates
 				pub #channel_name_unbounded:
 					#support_crate ::metered::UnboundedMeteredSender<
 						MessagePacket< #consumes >
@@ -70,7 +70,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 
 				let res: ::std::result::Result<_, _> = match message {
 				#(
-					#feature_guards
+					#feature_gates
 					#message_wrapper :: #consumes_variant ( inner ) => {
 						self. #channel_name .send(
 							#support_crate ::make_packet(signals_received, inner)
@@ -109,7 +109,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 			) {
 				let res: ::std::result::Result<_, _> = match message {
 				#(
-					#feature_guards
+					#feature_gates
 					#message_wrapper :: #consumes_variant (inner) => {
 						self. #channel_name_unbounded .unbounded_send(
 							#support_crate ::make_packet(signals_received, inner)

--- a/orchestra/proc-macro/src/impl_channels_out.rs
+++ b/orchestra/proc-macro/src/impl_channels_out.rs
@@ -30,6 +30,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 	let consumes_variant = &info.variant_names_without_wip();
 	let unconsumes_variant = &info.variant_names_only_wip();
 
+	let feature_guards = info.feature_gates();
 	let support_crate = info.support_crate_name();
 
 	let ts = quote! {
@@ -40,6 +41,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 		pub struct ChannelsOut {
 			#(
 				/// Bounded channel sender, connected to a subsystem.
+				#feature_guards
 				pub #channel_name:
 					#support_crate ::metered::MeteredSender<
 						MessagePacket< #consumes >
@@ -48,6 +50,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 
 			#(
 				/// Unbounded channel sender, connected to a subsystem.
+				#feature_guards
 				pub #channel_name_unbounded:
 					#support_crate ::metered::UnboundedMeteredSender<
 						MessagePacket< #consumes >
@@ -67,6 +70,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 
 				let res: ::std::result::Result<_, _> = match message {
 				#(
+					#feature_guards
 					#message_wrapper :: #consumes_variant ( inner ) => {
 						self. #channel_name .send(
 							#support_crate ::make_packet(signals_received, inner)
@@ -105,6 +109,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 			) {
 				let res: ::std::result::Result<_, _> = match message {
 				#(
+					#feature_guards
 					#message_wrapper :: #consumes_variant (inner) => {
 						self. #channel_name_unbounded .unbounded_send(
 							#support_crate ::make_packet(signals_received, inner)

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -21,7 +21,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 	let message_wrapper = &info.message_wrapper.clone();
 	let orchestra_name = info.orchestra_name.clone();
 	let subsystem_name = &info.subsystem_names_without_wip();
-	let feature_guards = &info.feature_gates();
+	let feature_gates = &info.feature_gates();
 	let support_crate = info.support_crate_name();
 
 	let baggage_decl = &info.baggage_decl();
@@ -69,7 +69,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 
 			#(
 				/// A subsystem instance.
-				#feature_guards
+				#feature_gates
 				#subsystem_name: OrchestratedSubsystem< #consumes >,
 			)*
 
@@ -103,7 +103,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			/// implementation specific.
 			pub async fn wait_terminate(&mut self, signal: #signal_ty, timeout: ::std::time::Duration) -> ::std::result::Result<(), #error_ty > {
 				#(
-					#feature_guards
+					#feature_gates
 					::std::mem::drop(self. #subsystem_name .send_signal(signal.clone()).await);
 				)*
 				let _ = signal;
@@ -129,7 +129,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			/// Broadcast a signal to all subsystems.
 			pub async fn broadcast_signal(&mut self, signal: #signal_ty) -> ::std::result::Result<(), #error_ty > {
 				#(
-					#feature_guards
+					#feature_gates
 					self. #subsystem_name .send_signal(signal.clone()).await?;
 				)*
 				let _ = signal;
@@ -141,13 +141,13 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			pub async fn route_message(&mut self, message: #message_wrapper, origin: &'static str) -> ::std::result::Result<(), #error_ty > {
 				match message {
 					#(
-						#feature_guards
+						#feature_gates
 						#message_wrapper :: #consumes_variant ( inner ) =>
 							OrchestratedSubsystem::< #consumes >::send_message2(&mut self. #subsystem_name, inner, origin ).await?,
 					)*
 					// subsystems that are still work in progress
 					#(
-						#feature_guards
+						#feature_gates
 						#message_wrapper :: #unconsumes_variant ( _ ) => {}
 					)*
 					#message_wrapper :: Empty => {}
@@ -171,7 +171,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			{
 				vec![
 				#(
-					#feature_guards
+					#feature_gates
 					mapper.map_subsystem( & self. #subsystem_name ),
 				)*
 				]

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -21,6 +21,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 	let message_wrapper = &info.message_wrapper.clone();
 	let orchestra_name = info.orchestra_name.clone();
 	let subsystem_name = &info.subsystem_names_without_wip();
+	let feature_guards = &info.feature_gates();
 	let support_crate = info.support_crate_name();
 
 	let baggage_decl = &info.baggage_decl();
@@ -68,6 +69,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 
 			#(
 				/// A subsystem instance.
+				#feature_guards
 				#subsystem_name: OrchestratedSubsystem< #consumes >,
 			)*
 
@@ -101,6 +103,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			/// implementation specific.
 			pub async fn wait_terminate(&mut self, signal: #signal_ty, timeout: ::std::time::Duration) -> ::std::result::Result<(), #error_ty > {
 				#(
+					#feature_guards
 					::std::mem::drop(self. #subsystem_name .send_signal(signal.clone()).await);
 				)*
 				let _ = signal;
@@ -126,6 +129,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			/// Broadcast a signal to all subsystems.
 			pub async fn broadcast_signal(&mut self, signal: #signal_ty) -> ::std::result::Result<(), #error_ty > {
 				#(
+					#feature_guards
 					self. #subsystem_name .send_signal(signal.clone()).await?;
 				)*
 				let _ = signal;
@@ -137,11 +141,13 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			pub async fn route_message(&mut self, message: #message_wrapper, origin: &'static str) -> ::std::result::Result<(), #error_ty > {
 				match message {
 					#(
+						#feature_guards
 						#message_wrapper :: #consumes_variant ( inner ) =>
 							OrchestratedSubsystem::< #consumes >::send_message2(&mut self. #subsystem_name, inner, origin ).await?,
 					)*
 					// subsystems that are still work in progress
 					#(
+						#feature_guards
 						#message_wrapper :: #unconsumes_variant ( _ ) => {}
 					)*
 					#message_wrapper :: Empty => {}
@@ -165,6 +171,7 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			{
 				vec![
 				#(
+					#feature_guards
 					mapper.map_subsystem( & self. #subsystem_name ),
 				)*
 				]

--- a/orchestra/proc-macro/src/parse/mod.rs
+++ b/orchestra/proc-macro/src/parse/mod.rs
@@ -24,7 +24,7 @@ mod kw {
 	syn::custom_keyword!(subsystem);
 	syn::custom_keyword!(prefix);
 }
-
+mod parse_cfg;
 mod parse_orchestra_attr;
 mod parse_orchestra_struct;
 

--- a/orchestra/proc-macro/src/parse/parse_cfg.rs
+++ b/orchestra/proc-macro/src/parse/parse_cfg.rs
@@ -145,16 +145,16 @@ mod test {
 
 	#[test]
 	fn cfg_item_sorts_and_compares_correctly() {
-		let item1: CfgItem = parse_quote! { feature = "bla1"};
-		let item2: CfgItem = parse_quote! { feature = "bla1"};
+		let item1: CfgItem = parse_quote! { feature = "f1"};
+		let item2: CfgItem = parse_quote! { feature = "f1"};
 		assert_eq!(true, item1 == item2);
 
-		let item1: CfgItem = parse_quote! { feature = "bla1"};
-		let item2: CfgItem = parse_quote! { feature = "bla2"};
+		let item1: CfgItem = parse_quote! { feature = "f1"};
+		let item2: CfgItem = parse_quote! { feature = "f2"};
 		assert_eq!(false, item1 == item2);
 		let mut item1: CfgItem = parse_quote! {
 			any(
-				all(feature = "bla1", feature = "bla2", feature = "bla3"),
+				all(feature = "f1", feature = "f2", feature = "f3"),
 				any(feature = "any1", feature = "any2"),
 				not(feature = "no")
 			)
@@ -163,7 +163,7 @@ mod test {
 			any(
 				not(feature = "no"),
 				any(feature = "any2", feature = "any1"),
-				all(feature = "bla2", feature = "bla1", feature = "bla3")
+				all(feature = "f2", feature = "f1", feature = "f3")
 			)
 		};
 		item1.sort_recursive();
@@ -177,10 +177,10 @@ mod test {
 			any(
 				not(feature = "no"),
 				any(feature = "any2", feature = "any1"),
-				all(feature = "bla2", feature = "bla1", feature = "bla3")
+				all(feature = "f2", feature = "f1", feature = "f3")
 			)
 		};
-		assert_eq!("any (not (feature = \"no\") , any (feature = \"any2\" , feature = \"any1\") , all (feature = \"bla2\" , feature = \"bla1\" , feature = \"bla3\"))"
+		assert_eq!("any (not (feature = \"no\") , any (feature = \"any2\" , feature = \"any1\") , all (feature = \"f2\" , feature = \"f1\" , feature = \"f3\"))"
 				   , to_parse.to_token_stream().to_string());
 	}
 }

--- a/orchestra/proc-macro/src/parse/parse_cfg.rs
+++ b/orchestra/proc-macro/src/parse/parse_cfg.rs
@@ -28,7 +28,11 @@ mod kw {
 	syn::custom_keyword!(feature);
 }
 
-/// Top-level cfg expression item
+/// Top-level cfg expression item without the initial "cfg" attribute but
+/// including parenthesis.
+/// Examples:
+///	- `(feature = "feature1")`
+///	- `(any(feature = "feature1", not(feature = "feature2")))`
 #[derive(Debug, Clone)]
 pub(crate) struct CfgExpressionRoot {
 	pub(crate) predicate: CfgPredicate,
@@ -43,7 +47,11 @@ impl Parse for CfgExpressionRoot {
 	}
 }
 
-/// Single cfg predicate for parsing.
+/// Potentially nested cfg predicate for parsing.
+///	Examples:
+///	- `feature = "feature1"`
+///	- `all(feature = "feature1", feature = "feature2")`
+///	- `not(feature = "feature2")`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub(crate) enum CfgPredicate {
 	Feature(String),

--- a/orchestra/proc-macro/src/parse/parse_cfg.rs
+++ b/orchestra/proc-macro/src/parse/parse_cfg.rs
@@ -1,0 +1,142 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use syn::{
+	ext::IdentExt,
+	parenthesized,
+	parse::{Parse, ParseStream},
+	parse2,
+	punctuated::Punctuated,
+	spanned::Spanned,
+	token,
+	token::Bracket,
+	AttrStyle, Error, Field, FieldsNamed, GenericParam, Ident, ItemStruct, LitInt, LitStr, Path,
+	PathSegment, Result, Token, Type, Visibility,
+};
+
+mod kw {
+	syn::custom_keyword!(not);
+	syn::custom_keyword!(all);
+	syn::custom_keyword!(any);
+	syn::custom_keyword!(feature);
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgExpressionRoot {
+	pub(crate) item: CfgItem,
+}
+
+#[derive(Debug, Clone)]
+pub enum CfgItem {
+	Feature(String),
+	All(Vec<CfgItem>),
+	Not(Vec<CfgItem>),
+	Any(Vec<CfgItem>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Feature {
+	feature: kw::feature,
+	assign: Token![=],
+	name: LitStr,
+}
+
+impl Parse for Feature {
+	fn parse(input: ParseStream) -> Result<Self> {
+		Ok(Self { feature: input.parse()?, assign: input.parse()?, name: input.parse()? })
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct All {
+	all: kw::all,
+	items: Punctuated<CfgItem, Token![,]>,
+}
+
+impl Parse for All {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let all = input.parse()?;
+		let content;
+		let _paren_token = parenthesized!(content in input);
+
+		Ok(Self { all, items: Punctuated::parse_terminated(&content)? })
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct Any {
+	any: kw::any,
+	items: Punctuated<CfgItem, Token![,]>,
+}
+
+impl Parse for Any {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let any = input.parse()?;
+		let content;
+		let _paren_token = parenthesized!(content in input);
+
+		Ok(Self { any, items: Punctuated::parse_terminated(&content)? })
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct Not {
+	not: kw::not,
+	items: Punctuated<CfgItem, Token![,]>,
+}
+
+impl Parse for Not {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let not = input.parse()?;
+		let content;
+		let _paren_token = parenthesized!(content in input);
+
+		Ok(Self { not, items: Punctuated::parse_terminated(&content)? })
+	}
+}
+
+impl Parse for CfgItem {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let lookahead = input.lookahead1();
+		if lookahead.peek(kw::all) {
+			let all: All = input.parse()?;
+			eprintln!("parsed all {all:?}");
+			return Ok(Self::All(Vec::from_iter(all.items.into_iter())))
+		} else if lookahead.peek(kw::any) {
+			let any: Any = input.parse()?;
+			eprintln!("parsed any {any:?}");
+			return Ok(Self::Any(Vec::from_iter(any.items.into_iter())))
+		} else if lookahead.peek(kw::not) {
+			let not: Not = input.parse()?;
+			eprintln!("parsed not {not:?}");
+			return Ok(Self::Any(Vec::from_iter(not.items.into_iter())))
+		} else if lookahead.peek(kw::feature) {
+			let feature: Feature = input.parse()?;
+			eprintln!("parsed feature {feature:?}");
+			return Ok(Self::Feature(feature.name.value()))
+		}
+		Err(Error::new(input.span(), "yolo"))
+	}
+}
+
+impl Parse for CfgExpressionRoot {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let content;
+		let _paren_token = parenthesized!(content in input);
+		eprintln!("==============================");
+
+		Ok(Self { item: content.parse()? })
+	}
+}

--- a/orchestra/proc-macro/src/parse/parse_cfg.rs
+++ b/orchestra/proc-macro/src/parse/parse_cfg.rs
@@ -44,7 +44,7 @@ impl Parse for CfgExpressionRoot {
 }
 
 /// Single cfg predicate for parsing.
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub(crate) enum CfgPredicate {
 	Feature(String),
 	All(Vec<CfgPredicate>),

--- a/orchestra/proc-macro/src/parse/parse_cfg.rs
+++ b/orchestra/proc-macro/src/parse/parse_cfg.rs
@@ -61,6 +61,7 @@ pub(crate) enum CfgPredicate {
 }
 
 impl CfgPredicate {
+	/// Recursively sort this predicate and all nested predicates.
 	pub(crate) fn sort_recursive(&mut self) {
 		match self {
 			CfgPredicate::All(predicates) | CfgPredicate::Any(predicates) => {
@@ -70,6 +71,11 @@ impl CfgPredicate {
 			CfgPredicate::Not(p) => p.sort_recursive(),
 			_ => {},
 		}
+	}
+
+	/// Consume self and return conjunction with another predicate.
+	pub(crate) fn merge(self, other: CfgPredicate) -> CfgPredicate {
+		Self::All(vec![self, other])
 	}
 }
 

--- a/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
+++ b/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
@@ -659,18 +659,11 @@ impl OrchestraGuts {
 					})
 				});
 
-			let ident = ident.ok_or_else(|| {
-				Error::new(
-					ty.span(),
-					"Missing identifier for field, only named fields are expected.",
-				)
-			})?;
-
 			let feature_gates = if let Some((attr_tokens, span)) = cfg_attr.next() {
 				// multiple `#[cfg(..)]` found
 				if let Some((_attr_tokens2, span2)) = cfg_attr.next() {
 					return Err({
-						let mut err = Error::new(span, "The first subsystem annotation is at");
+						let mut err = Error::new(span, "The first cfg annotation is at");
 						err.combine(Error::new(span2, "but another here for the same field."));
 						err
 					})
@@ -682,6 +675,13 @@ impl OrchestraGuts {
 			} else {
 				None
 			};
+
+			let ident = ident.ok_or_else(|| {
+				Error::new(
+					ty.span(),
+					"Missing identifier for field, only named fields are expected.",
+				)
+			})?;
 
 			if let Some((attr_tokens, span)) = subsystem_attr.next() {
 				// a `#[subsystem(..)]` annotation exists

--- a/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
+++ b/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
@@ -585,17 +585,6 @@ impl OrchestraInfo {
 			.collect_vec()
 	}
 
-	pub(crate) fn feature_gates_inverted(&self) -> Vec<TokenStream> {
-		self.subsystems
-			.iter()
-			.map(|s| {
-				s.feature_guard
-					.clone()
-					.map_or(quote! {}, |fg| quote! { #[cfg(not(feature = #fg))] })
-			})
-			.collect::<Vec<_>>()
-	}
-
 	pub(crate) fn subsystem_names_without_wip(&self) -> Vec<Ident> {
 		self.subsystems
 			.iter()
@@ -673,22 +662,6 @@ impl OrchestraInfo {
 			.collect::<Vec<_>>()
 	}
 
-	pub(crate) fn message_channel_capacities_without_wip(
-		&self,
-		default_capacity: usize,
-	) -> Vec<LitInt> {
-		self.subsystems
-			.iter()
-			.filter(|ssf| !ssf.wip)
-			.map(|ssf| {
-				LitInt::new(
-					&(ssf.message_capacity.unwrap_or(default_capacity).to_string()),
-					ssf.message_capacity.span(),
-				)
-			})
-			.collect::<Vec<_>>()
-	}
-
 	pub(crate) fn message_channel_capacities_without_wip2(
 		&self,
 		default_capacity: usize,
@@ -706,28 +679,12 @@ impl OrchestraInfo {
 			.collect::<Vec<_>>()
 	}
 
-	pub(crate) fn signal_channel_capacities_without_wip(
-		&self,
-		default_capacity: usize,
-	) -> Vec<LitInt> {
-		self.subsystems
-			.iter()
-			.filter(|ssf| !ssf.wip)
-			.map(|ssf| {
-				LitInt::new(
-					&(ssf.signal_capacity.unwrap_or(default_capacity).to_string()),
-					ssf.signal_capacity.span(),
-				)
-			})
-			.collect::<Vec<_>>()
-	}
-
 	pub(crate) fn signal_channel_capacities_without_wip2(
 		&self,
 		default_capacity: usize,
 		subsystems: &Vec<SubSysField>,
 	) -> Vec<LitInt> {
-		self.subsystems
+		subsystems
 			.iter()
 			.filter(|ssf| !ssf.wip)
 			.map(|ssf| {

--- a/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
+++ b/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
@@ -13,10 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::parse_cfg::*;
 use itertools::Itertools;
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
 use std::collections::{hash_map::RandomState, HashMap, HashSet};
 use syn::{
+	ext::IdentExt,
 	parenthesized,
 	parse::{Parse, ParseStream},
 	parse2,
@@ -27,8 +30,6 @@ use syn::{
 	AttrStyle, Error, Field, FieldsNamed, GenericParam, Ident, ItemStruct, LitInt, LitStr, Path,
 	PathSegment, Result, Token, Type, Visibility,
 };
-
-use quote::{quote, ToTokens};
 
 mod kw {
 	syn::custom_keyword!(wip);
@@ -693,10 +694,18 @@ impl OrchestraGuts {
 						err
 					})
 				}
+				let items = syn::parse2::<CfgAttrItems>(attr_tokens.clone())?.items;
+				let _test = syn::parse2::<CfgExpressionRoot>(attr_tokens)?.item;
+				let bla = items.clone();
 
+				// eprintln!("======Attr: {}", bla.to_string());
+				// bla.into_iter().for_each(|item| {
+				// 	eprintln!("String: {item}");
+				// 	eprintln!("Item: {item:?}");
+				// });
 				// Extract the inner condition without parenthesis
 				// #[cfg(feature = "feature")] -> feature = "feature"
-				Some(syn::parse2::<CfgAttrItems>(attr_tokens)?.items)
+				Some(items)
 			} else {
 				None
 			};

--- a/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
+++ b/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
@@ -527,11 +527,11 @@ impl OrchestraInfo {
 					enabled.clone().iter().map(|e| e.to_string()).collect_vec();
 				let guard = if disabled.is_empty() {
 					quote! {
-						#[cfg(all(#(#enabled,)*))]
+						#[cfg(all(#(#enabled),*))]
 					}
 				} else {
 					quote! {
-						#[cfg(all(#(#enabled,)* not(any(#(#disabled,)*))))]
+						#[cfg(all(#(#enabled,)* not(any(#(#disabled),*))))]
 					}
 				};
 				let enabled = self

--- a/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
+++ b/orchestra/proc-macro/src/parse/parse_orchestra_struct.rs
@@ -534,7 +534,7 @@ impl OrchestraInfo {
 			.iter()
 			.filter_map(|s| s.feature_gates.clone())
 			// We assume that the feature gates are already sorted internally
-			.dedup()
+			.unique()
 			.powerset()
 			.collect_vec();
 


### PR DESCRIPTION
In this PR I introduce guarding of subsystems via features.
Supported syntax:
```rust
#[orchestra(signal=Signal, event=ExternalEvent, error=SubsystemError, gen=AllMessages)]
struct MyOverseer<T, U, V, W> {
	#[cfg(feature = "feature1")]
	#[subsystem(consumes: Subsystem1Message, sends: [Subsystem2Message])]
	subsystem1: Sub1,

	#[subsystem(consumes: Subsystem2Message, sends: [Subsystem1Message])]
	subsystem2: Sub2,
}
```
Basically this allows re-use of one orchestra in scenarios where it is not needed to run all subsystems. The `#cfg` attribute macro currently supports `any`, `all`, `not` and `feature = "something"`.

## Limitations
- Feature unification. The current implementation is not very useful when you have a large workspace, and different crates depend on the defined orchestra with different features enabled.

- Performance depends on the number of unique cfg expressions defined in the crate. With the current design of the orchestra builder, I have to build distinct feature combinations for the builder. This scales with O(2^n) where n is the number of distinct feature expressions. I tested a bit and impact is starting to show at around 7 different feature expressions.