### PR TITLE
Add try_send method to the orchestra output channels

### DIFF
--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -127,6 +127,15 @@ impl<T> MeteredReceiver<T> {
 		}
 	}
 
+	/// Attempt to receive the next item without blocking
+	pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+		match self.inner.try_recv() {
+			Ok(value) =>
+				Ok(self.maybe_meter_tof(Some(value)).expect("wrapped value is always Some, qed")),
+			Err(err) => Err(err),
+		}
+	}
+
 	/// Returns the current number of messages in the channel
 	pub fn len(&self) -> usize {
 		self.inner.len()

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -16,7 +16,7 @@
 
 //! Metered variant of bounded mpsc channels to be able to extract metrics.
 
-use async_channel::{bounded, TryRecvError, TrySendError};
+use async_channel::{bounded, TryRecvError};
 use futures::{
 	stream::Stream,
 	task::{Context, Poll},
@@ -24,6 +24,7 @@ use futures::{
 use std::{pin::Pin, result};
 
 use super::{measure_tof_check, CoarseInstant, MaybeTimeOfFlight, Meter};
+pub use async_channel::TrySendError;
 
 /// Create a wrapped `mpsc::channel` pair of `MeteredSender` and `MeteredReceiver`.
 pub fn channel<T>(capacity: usize) -> (MeteredSender<T>, MeteredReceiver<T>) {
@@ -44,9 +45,18 @@ pub struct MeteredReceiver<T> {
 
 /// A bounded channel error
 #[derive(thiserror::Error, Debug)]
-pub enum SendError {
+pub enum SendError<T> {
 	#[error("Bounded channel has been disconnected")]
-	Disconnected,
+	Disconnected(T),
+}
+
+impl<T> SendError<T> {
+	/// Returns the inner value.
+	pub fn into_inner(self) -> T {
+		match self {
+			Self::Disconnected(t) => t,
+		}
+	}
 }
 
 impl<T> std::ops::Deref for MeteredReceiver<T> {
@@ -164,23 +174,23 @@ impl<T> MeteredSender<T> {
 	}
 
 	/// Send message, wait until capacity is available.
-	pub async fn send(&mut self, msg: T) -> result::Result<(), SendError>
+	pub async fn send(&mut self, msg: T) -> result::Result<(), SendError<T>>
 	where
 		Self: Unpin,
 	{
 		match self.try_send(msg) {
 			Err(send_err) => {
 				if !send_err.is_full() {
-					return Err(SendError::Disconnected)
+					return Err(SendError::Disconnected(send_err.into_inner().into()))
 				}
 
-				let msg = send_err.into_inner();
+				let msg = send_err.into_inner().into();
 				self.meter.note_sent();
 				let fut = self.inner.send(msg);
 				futures::pin_mut!(fut);
-				fut.await.map_err(|_| {
+				fut.await.map_err(|err| {
 					self.meter.retract_sent();
-					SendError::Disconnected
+					SendError::Disconnected(err.0.into())
 				})
 			},
 			_ => Ok(()),
@@ -188,15 +198,17 @@ impl<T> MeteredSender<T> {
 	}
 
 	/// Attempt to send message or fail immediately.
-	pub fn try_send(&mut self, msg: T) -> result::Result<(), TrySendError<MaybeTimeOfFlight<T>>> {
+	pub fn try_send(&mut self, msg: T) -> result::Result<(), TrySendError<T>> {
 		let msg = self.prepare_with_tof(msg);
 		self.inner.try_send(msg).map_err(|e| {
-			if e.is_full() {
-				// Count bounded channel sends that block.
-				self.meter.note_blocked();
-			}
 			self.meter.retract_sent();
-			e
+			match e {
+				TrySendError::Full(inner_error) => {
+					self.meter.note_blocked();
+					TrySendError::Full(inner_error.into())
+				},
+				TrySendError::Closed(inner_error) => TrySendError::Closed(inner_error.into()),
+			}
 		})
 	}
 

--- a/orchestra/examples/duo.rs
+++ b/orchestra/examples/duo.rs
@@ -35,6 +35,7 @@ impl<Context> AwesomeSubSys {
 		ctx.spawn(
 			"AwesomeSubsys",
 			Box::pin(async move {
+				sender.try_send_message(Plinko).unwrap();
 				sender.send_message(Plinko).await;
 			}),
 		)
@@ -53,6 +54,7 @@ impl<Context> Fortified {
 		ctx.spawn(
 			"GoblinTower",
 			Box::pin(async move {
+				sender.try_send_message(MsgStrukt(8u8)).unwrap();
 				sender.send_message(MsgStrukt(8u8)).await;
 			}),
 		)

--- a/orchestra/proc-macro/src/impl_channels_out.rs
+++ b/orchestra/proc-macro/src/impl_channels_out.rs
@@ -105,7 +105,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 				&mut self,
 				signals_received: usize,
 				message: #message_wrapper,
-			) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<()>> {
+			) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<#message_wrapper>> {
 				let res: ::std::result::Result<_, _> = match message {
 				#(
 					#feature_gates
@@ -113,8 +113,8 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 						self. #channel_name .try_send(
 							#support_crate ::make_packet(signals_received, inner)
 						).map_err(|err| match err {
-								#support_crate ::metered::TrySendError::Full(_inner) => #support_crate ::metered::TrySendError::Full(()),
-								#support_crate ::metered::TrySendError::Closed(_inner) => #support_crate ::metered::TrySendError::Closed(()),
+								#support_crate ::metered::TrySendError::Full(err_inner) => #support_crate ::metered::TrySendError::Full(#message_wrapper:: #consumes_variant ( err_inner.message )),
+								#support_crate ::metered::TrySendError::Closed(err_inner) => #support_crate ::metered::TrySendError::Closed(#message_wrapper:: #consumes_variant ( err_inner.message )),
 						})
 					}
 				)*

--- a/orchestra/proc-macro/src/impl_channels_out.rs
+++ b/orchestra/proc-macro/src/impl_channels_out.rs
@@ -61,27 +61,61 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 		#[allow(unreachable_code)]
 		// when no defined messages in enum
 		impl ChannelsOut {
-			async fn send_or_try(&mut self,
+			/// Send a message via a bounded channel.
+			pub async fn send_and_log_error(
+				&mut self,
 				signals_received: usize,
 				message: #message_wrapper,
-				try_send: bool) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<()>> {
-				let res: ::std::result::Result<(), #support_crate ::metered::TrySendError<()>> = match message {
+			) {
+				let res: ::std::result::Result<_, _> = match message {
 				#(
 					#feature_gates
 					#message_wrapper :: #consumes_variant ( inner ) => {
-						if try_send {
-							self. #channel_name .try_send(
-								#support_crate ::make_packet(signals_received, inner)
-							).map_err(|err| match err {
-									#support_crate ::metered::TrySendError::Full(_inner) => #support_crate ::metered::TrySendError::Full(()),
-									#support_crate ::metered::TrySendError::Closed(_inner) => #support_crate ::metered::TrySendError::Closed(()),
-								})
-						}
-						else {
-							self. #channel_name .send(
-								#support_crate ::make_packet(signals_received, inner)
-							).await.map_err(|_| #support_crate ::metered::TrySendError::Closed(()))
-						}
+						self. #channel_name .send(
+							#support_crate ::make_packet(signals_received, inner)
+						).await.map_err(|_| stringify!( #channel_name ))
+					}
+				)*
+					// subsystems that are wip
+				#(
+					#message_wrapper :: #unconsumes_variant ( _ ) => Ok(()),
+				)*
+					// dummy message type
+					#message_wrapper :: Empty => Ok(()),
+
+					#[allow(unreachable_patterns)]
+					// And everything that's not WIP but no subsystem consumes it
+					unused_msg => {
+						#support_crate :: tracing :: warn!("Nothing consumes {:?}", unused_msg);
+						Ok(())
+					}
+				};
+
+				if let Err(subsystem_name) = res {
+					#support_crate ::tracing::debug!(
+						target: LOG_TARGET,
+						"Failed to send (bounded) a message to {} subsystem",
+						subsystem_name
+					);
+				}
+			}
+
+			/// Try to send a message via a bounded channel.
+			pub fn try_send(
+				&mut self,
+				signals_received: usize,
+				message: #message_wrapper,
+			) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<()>> {
+				let res: ::std::result::Result<_, _> = match message {
+				#(
+					#feature_gates
+					#message_wrapper :: #consumes_variant ( inner ) => {
+						self. #channel_name .try_send(
+							#support_crate ::make_packet(signals_received, inner)
+						).map_err(|err| match err {
+								#support_crate ::metered::TrySendError::Full(_inner) => #support_crate ::metered::TrySendError::Full(()),
+								#support_crate ::metered::TrySendError::Closed(_inner) => #support_crate ::metered::TrySendError::Closed(()),
+						})
 					}
 				)*
 					// subsystems that are wip
@@ -100,30 +134,6 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 				};
 
 				res
-			}
-			/// Send a message via a bounded channel.
-			pub async fn send_and_log_error(
-				&mut self,
-				signals_received: usize,
-				message: #message_wrapper,
-			) {
-				let res = self.send_or_try(signals_received, message, false).await;
-				if let Err(subsystem_name) = res {
-					#support_crate ::tracing::debug!(
-						target: LOG_TARGET,
-						"Failed to send (bounded) a message to {} subsystem",
-						subsystem_name
-					);
-				}
-			}
-
-			/// Try to send a message via a bounded channel.
-			pub async fn try_send(
-				&mut self,
-				signals_received: usize,
-				message: #message_wrapper,
-			) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<()>> {
-				self.send_or_try(signals_received, message, true).await
 			}
 
 			/// Send a message to another subsystem via an unbounded channel.

--- a/orchestra/proc-macro/src/impl_message_wrapper.rs
+++ b/orchestra/proc-macro/src/impl_message_wrapper.rs
@@ -89,11 +89,12 @@ pub(crate) fn impl_message_wrapper_enum(info: &OrchestraInfo) -> Result<proc_mac
 				}
 			}
 
-			impl ::std::convert::From< #message_wrapper > for #consumes {
-				fn from(message: #message_wrapper) -> Self {
+			impl ::std::convert::TryFrom< #message_wrapper > for #consumes {
+				type Error = ();
+				fn try_from(message: #message_wrapper) -> ::std::result::Result<Self, Self::Error> {
 					match message {
-						#message_wrapper :: #consumes_variant ( inner ) => inner,
-						_ => panic!("Message is not of type {}", stringify!(#consumes)),
+						#message_wrapper :: #consumes_variant ( inner ) => Ok(inner),
+						_ => Err(()),
 					}
 				}
 			}

--- a/orchestra/proc-macro/src/impl_message_wrapper.rs
+++ b/orchestra/proc-macro/src/impl_message_wrapper.rs
@@ -73,10 +73,28 @@ pub(crate) fn impl_message_wrapper_enum(info: &OrchestraInfo) -> Result<proc_mac
 			}
 		}
 
+		impl ::std::convert::From< #message_wrapper > for () {
+			fn from(message: #message_wrapper) -> Self {
+				match message {
+					#message_wrapper :: Empty => (),
+					_ => panic!("Message is not of type {}", stringify!(#message_wrapper)),
+				}
+			}
+		}
+
 		#(
 			impl ::std::convert::From< #consumes > for #message_wrapper {
 				fn from(message: #consumes) -> Self {
 					#message_wrapper :: #consumes_variant ( message )
+				}
+			}
+
+			impl ::std::convert::From< #message_wrapper > for #consumes {
+				fn from(message: #message_wrapper) -> Self {
+					match message {
+						#message_wrapper :: #consumes_variant ( inner ) => inner,
+						_ => panic!("Message is not of type {}", stringify!(#consumes)),
+					}
 				}
 			}
 		)*

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -233,8 +233,8 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 								#support_crate ::OrchestraError::SubsystemStalled(instance.name, "message", ::std::any::type_name::<M>())
 							))
 						}
-						Some(res) => res.map_err(|e| #error_ty :: from(
-								#support_crate ::OrchestraError::QueueError(e)
+						Some(res) => res.map_err(|_| #error_ty :: from(
+								#support_crate ::OrchestraError::QueueError
 							)),
 					}
 				} else {
@@ -256,8 +256,8 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 							))
 						}
 						Some(res) => {
-							let res = res.map_err(|e| #error_ty :: from(
-								#support_crate ::OrchestraError::QueueError(e)
+							let res = res.map_err(|_| #error_ty :: from(
+								#support_crate ::OrchestraError::QueueError
 							));
 							if res.is_ok() {
 								instance.signals_received += 1;

--- a/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
+++ b/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
@@ -279,6 +279,16 @@ pub(crate) fn impl_subsystem_sender(
 					).await;
 				}
 
+				fn try_send_message(&mut self, msg: OutgoingMessage) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<()>>
+				{
+					self.channels.try_send(
+						self.signals_received.load(),
+						<#all_messages_wrapper as ::std::convert::From<_>> ::from (
+							<#outgoing_wrapper as ::std::convert::From<_>> :: from ( msg )
+						)
+					)
+				}
+
 				async fn send_messages<I>(&mut self, msgs: I)
 				where
 					I: IntoIterator<Item=OutgoingMessage> + Send,

--- a/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
+++ b/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
@@ -73,14 +73,15 @@ pub(crate) fn impl_subsystem_types_all(info: &OrchestraInfo) -> Result<TokenStre
 				}
 			}
 
-			impl ::std::convert::From< #all_messages_wrapper > for #outgoing_wrapper {
-				fn from(message: #all_messages_wrapper) -> Self {
+			impl ::std::convert::TryFrom< #all_messages_wrapper > for #outgoing_wrapper {
+				type Error = ();
+				fn try_from(message: #all_messages_wrapper) -> ::std::result::Result<Self, Self::Error> {
 					match message {
 					#(
-						#all_messages_wrapper :: #subsystem_generic ( msg ) => #outgoing_wrapper :: #outgoing_variant ( msg ),
+						#all_messages_wrapper :: #subsystem_generic ( msg ) => Ok(#outgoing_wrapper :: #outgoing_variant ( msg )),
 					)*
-						#all_messages_wrapper :: Empty => #outgoing_wrapper :: Empty,
-						_ => unreachable!("All messages should be consumed by a subsystem"),
+						#all_messages_wrapper :: Empty => Ok(#outgoing_wrapper :: Empty),
+						_ => Err(()),
 					}
 				}
 			}
@@ -277,9 +278,10 @@ pub(crate) fn impl_subsystem_sender(
 			#[#support_crate ::async_trait]
 			impl<OutgoingMessage> SubsystemSender< OutgoingMessage > for #subsystem_sender_name < #outgoing_wrapper >
 			where
-				OutgoingMessage: ::std::convert::From<#all_messages_wrapper> + Send + 'static,
+				OutgoingMessage: ::std::convert::TryFrom<#all_messages_wrapper> + Send + 'static,
 				#outgoing_wrapper: ::std::convert::From<OutgoingMessage> + Send,
 				#all_messages_wrapper: ::std::convert::From< #outgoing_wrapper > + Send,
+				 <OutgoingMessage as ::std::convert::TryFrom<AllMessages>>::Error: ::std::fmt::Debug,
 			{
 				async fn send_message(&mut self, msg: OutgoingMessage)
 				{
@@ -299,8 +301,8 @@ pub(crate) fn impl_subsystem_sender(
 							<#outgoing_wrapper as ::std::convert::From<_>> :: from ( msg )
 						)
 					).map_err(|err| match err {
-								#support_crate ::metered::TrySendError::Full(inner) => #support_crate ::metered::TrySendError::Full(inner.into()),
-								#support_crate ::metered::TrySendError::Closed(inner) => #support_crate ::metered::TrySendError::Closed(inner.into()),
+								#support_crate ::metered::TrySendError::Full(inner) => #support_crate ::metered::TrySendError::Full(inner.try_into().expect("we should be able to unwrap what we wrap, qed")),
+								#support_crate ::metered::TrySendError::Closed(inner) => #support_crate ::metered::TrySendError::Closed(inner.try_into().expect("we should be able to unwrap what we wrap, qed")),
 						})
 				}
 

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -496,6 +496,12 @@ where
 	/// Send a direct message to some other `Subsystem`, routed based on message type.
 	async fn send_message(&mut self, msg: OutgoingMessage);
 
+	/// Tries to send a direct message to some other `Subsystem`, routed based on message type.
+	/// This method is useful for cases where the message queue is bounded and the message is ok
+	/// to be dropped if the queue is full. If the queue is full, this method will return an error.
+	/// This method is not async and will not block the current task.
+	fn try_send_message(&mut self, msg: OutgoingMessage) -> Result<(), metered::TrySendError<()>>;
+
 	/// Send multiple direct messages to other `Subsystem`s, routed based on message type.
 	async fn send_messages<I>(&mut self, msgs: I)
 	where

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -274,8 +274,8 @@ pub enum OrchestraError {
 	#[error(transparent)]
 	NotifyCancellation(#[from] oneshot::Canceled),
 
-	#[error(transparent)]
-	QueueError(#[from] metered::SendError),
+	#[error("Queue error")]
+	QueueError,
 
 	#[error("Failed to spawn task {0}")]
 	TaskSpawn(&'static str),
@@ -298,6 +298,12 @@ pub enum OrchestraError {
 		#[source]
 		source: Box<dyn 'static + std::error::Error + Send + Sync>,
 	},
+}
+
+impl<T> From<metered::SendError<T>> for OrchestraError {
+	fn from(_err: metered::SendError<T>) -> Self {
+		Self::QueueError
+	}
 }
 
 /// Alias for a result with error type `OrchestraError`.

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -500,7 +500,10 @@ where
 	/// This method is useful for cases where the message queue is bounded and the message is ok
 	/// to be dropped if the queue is full. If the queue is full, this method will return an error.
 	/// This method is not async and will not block the current task.
-	fn try_send_message(&mut self, msg: OutgoingMessage) -> Result<(), metered::TrySendError<()>>;
+	fn try_send_message(
+		&mut self,
+		msg: OutgoingMessage,
+	) -> Result<(), metered::TrySendError<OutgoingMessage>>;
 
 	/// Send multiple direct messages to other `Subsystem`s, routed based on message type.
 	async fn send_messages<I>(&mut self, msgs: I)


### PR DESCRIPTION
This PR addresses #44. WIP currently:

- [x] Initial implementation of the `try_send` in channels
- [x] Think more about error type
- [x] Add tests