### PR TITLE
Send signals in parallel

### DIFF
--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -61,6 +61,8 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 
 		/// Capacity of a signal channel between a subsystem and the orchestra.
 		const SIGNAL_CHANNEL_CAPACITY: usize = #signal_channel_capacity;
+		/// Timeout to wait for a signal to be processed by the target subsystem. If this timeout is exceeded, the
+		/// orchestra terminates with an error.
 		const SIGNAL_TIMEOUT: ::std::time::Duration = ::std::time::Duration::from_secs(10);
 
 		/// The log target tag.
@@ -292,10 +294,9 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 			/// Tries to send a signal to the wrapped subsystem without waiting.
 			pub fn try_send_signal(&mut self, signal: #signal) -> ::std::result::Result<(), #support_crate :: TrySendError<#signal> > {
 				if let Some(ref mut instance) = self.instance {
-					if let Ok(()) = instance.tx_signal.try_send(signal)? {
-						instance.signals_received += 1;
-						Ok(())
-					}
+					instance.tx_signal.try_send(signal)?;
+					instance.signals_received += 1;
+					Ok(())
 				} else {
 					Ok(())
 				}

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -91,6 +91,9 @@ use std::sync::{
 pub use std::time::Duration;
 
 #[doc(hidden)]
+pub use metered::TrySendError;
+
+#[doc(hidden)]
 pub use futures_timer::Delay;
 
 use std::fmt;


### PR DESCRIPTION
This PR addresses #18

Rough architecture description.

1) We first try to send signals via `try_send_signal` for each subsystem. This is not an async function and it is blazingly fast for the vast majority of the cases. So it is a fast path.
2) If some subsystem is slow, then we create a new future where we perform the real async `send_signal` function.
3) These futures are joint in `FuturesUnordered` to allow unordered polling. When some subsystem gets ready to accept a signal it immediately receives that signal.

With such an approach, we do not create unnecessary futures nor vectors of futures and we just utilise the fast path via `try_send` in the majority of this function calls.