### PR TITLE
feat: add convenience conversion for TrySend error

### DIFF
--- a/metered-channel/Cargo.toml
+++ b/metered-channel/Cargo.toml
@@ -31,4 +31,3 @@ tracing = { version = "0.1.35", features = ["log"] }
 default = ["async_channel"]
 async_channel = ["dep:async-channel"]
 futures_channel = []
-

--- a/orchestra/Cargo.toml
+++ b/orchestra/Cargo.toml
@@ -39,7 +39,7 @@ name = "bench_main"
 harness = false
 
 [features]
-default = ["deny_unconsumed_messages","deny_unsent_messages","async_channel"]
+default = ["deny_unconsumed_messages", "deny_unsent_messages", "async_channel"]
 # Generate a file containing the generated code that
 # is used via `include_str!`.
 expand = ["orchestra-proc-macro/expand"]


### PR DESCRIPTION
#48 introduced aliasing error types, but didn't provide publicly acessible `From<_>` implementations. This PR adds those and makes use of them internally.