### PR TITLE
chore: more transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "orchestra"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "criterion",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_matches",


### PR DESCRIPTION
Adds more transforms for generalized test harness support in our codebase. It's just a pain to have match statements when I really want to transform the inner value of both enum variants. Technically we might want to consider to move to a `struct` + flat + `enum`-kind type approach, but that's for later I guess.