### PR TITLE
Add meter for channel len

### DIFF
--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -239,8 +239,6 @@ impl<T> MeteredReceiver<T> {
 			.into()
 		});
 
-		#[cfg(feature = "async_channel")]
-		self.meter.note_channel_len(self.inner.len());
 		result
 	}
 
@@ -261,30 +259,39 @@ impl<T> MeteredReceiver<T> {
 	/// Attempt to receive the next item.
 	#[cfg(feature = "async_channel")]
 	pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
-		match self.inner.try_recv() {
+		let result = match self.inner.try_recv() {
 			Ok(value) => Ok(self.maybe_meter_tof(Some(value))),
 			Err(err) => Err(err),
-		}
+		};
+
+		self.meter.note_channel_len(self.len());
+		result
 	}
 
 	/// Receive the next item.
 	#[cfg(feature = "async_channel")]
 	pub async fn recv(&mut self) -> Result<T, RecvError> {
-		match self.inner.recv().await {
+		let result = match self.inner.recv().await {
 			Ok(value) =>
 				Ok(self.maybe_meter_tof(Some(value)).expect("wrapped value is always Some, qed")),
 			Err(err) => Err(err.into()),
-		}
+		};
+
+		self.meter.note_channel_len(self.len());
+		result
 	}
 
 	/// Attempt to receive the next item without blocking
 	#[cfg(feature = "async_channel")]
 	pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
-		match self.inner.try_recv() {
+		let result = match self.inner.try_recv() {
 			Ok(value) =>
 				Ok(self.maybe_meter_tof(Some(value)).expect("wrapped value is always Some, qed")),
 			Err(err) => Err(err),
-		}
+		};
+
+		self.meter.note_channel_len(self.len());
+		result
 	}
 
 	#[cfg(feature = "async_channel")]
@@ -335,8 +342,6 @@ impl<T> MeteredSender<T> {
 		} else {
 			MaybeTimeOfFlight::Bare(item)
 		};
-		#[cfg(feature = "async_channel")]
-		self.meter.note_channel_len(self.inner.len());
 
 		item
 	}
@@ -360,10 +365,7 @@ impl<T> MeteredSender<T> {
 				self.meter.note_blocked();
 				self.meter.note_sent(); // we are going to do full blocking send, so we have to note it here
 				let msg = send_err.into_inner().into();
-				let result = self.send_to_channel(msg).await;
-				#[cfg(feature = "async_channel")]
-				self.meter.note_channel_len(self.inner.len());
-				result
+				self.send_to_channel(msg).await
 			},
 			_ => Ok(()),
 		}
@@ -377,10 +379,13 @@ impl<T> MeteredSender<T> {
 	) -> result::Result<(), SendError<T>> {
 		let fut = self.inner.send(msg);
 		futures::pin_mut!(fut);
-		fut.await.map_err(|err| {
+		let result = fut.await.map_err(|err| {
 			self.meter.retract_sent();
 			SendError::Closed(err.0.into())
-		})
+		});
+
+		self.meter.note_channel_len(self.len());
+		result
 	}
 
 	#[cfg(feature = "futures_channel")]
@@ -412,10 +417,13 @@ impl<T> MeteredSender<T> {
 	/// Attempt to send message or fail immediately.
 	pub fn try_send(&mut self, msg: T) -> result::Result<(), TrySendError<T>> {
 		let msg = self.prepare_with_tof(msg); // note_sent is called in here
-		self.inner.try_send(msg).map_err(|e| {
+		let result = self.inner.try_send(msg).map_err(|e| {
 			self.meter.retract_sent(); // we didn't send it, so we need to undo the note_send
 			TrySendError::from(e)
-		})
+		});
+
+		self.meter.note_channel_len(self.len());
+		result
 	}
 
 	#[cfg(feature = "async_channel")]

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -225,7 +225,7 @@ impl<T> MeteredReceiver<T> {
 	fn maybe_meter_tof(&mut self, maybe_value: Option<MaybeTimeOfFlight<T>>) -> Option<T> {
 		self.meter.note_received();
 
-		let result = maybe_value.map(|value| {
+		maybe_value.map(|value| {
 			match value {
 				MaybeTimeOfFlight::<T>::WithTimeOfFlight(value, tof_start) => {
 					// do not use `.elapsed()` of `std::time`, it may panic
@@ -237,9 +237,7 @@ impl<T> MeteredReceiver<T> {
 				MaybeTimeOfFlight::<T>::Bare(value) => value,
 			}
 			.into()
-		});
-
-		result
+		})
 	}
 
 	/// Get an updated accessor object for all metrics collected.

--- a/metered-channel/src/lib.rs
+++ b/metered-channel/src/lib.rs
@@ -107,17 +107,25 @@ impl Meter {
 	}
 
 	fn note_sent(&self) -> usize {
+		#[cfg(feature = "futures_channel")]
 		self.channel_len.fetch_add(1, Ordering::Relaxed);
 		self.sent.fetch_add(1, Ordering::Relaxed)
 	}
 
 	fn retract_sent(&self) {
 		self.sent.fetch_sub(1, Ordering::Relaxed);
+		#[cfg(feature = "futures_channel")]
 		self.channel_len.fetch_add(1, Ordering::Relaxed);
+	}
+
+	#[cfg(feature = "async_channel")]
+	fn note_channel_len(&self, len: usize) {
+		self.channel_len.store(len, Ordering::Relaxed);
 	}
 
 	fn note_received(&self) {
 		self.received.fetch_add(1, Ordering::Relaxed);
+		#[cfg(feature = "futures_channel")]
 		self.channel_len.fetch_sub(1, Ordering::Relaxed);
 	}
 

--- a/metered-channel/src/tests.rs
+++ b/metered-channel/src/tests.rs
@@ -39,12 +39,12 @@ fn try_send_try_next() {
 		assert_matches!(rx.meter().read(), Readout { sent: 4, received: 1, .. });
 		rx.try_next().unwrap();
 		rx.try_next().unwrap();
-		assert_matches!(tx.meter().read(), Readout { sent: 4, received: 3, blocked: 0, tof } => {
+		assert_matches!(tx.meter().read(), Readout { sent: 4, received: 3,  channel_len: 1, blocked: 0, tof } => {
 			// every second in test, consumed before
 			assert_eq!(dbg!(tof).len(), 1);
 		});
 		rx.try_next().unwrap();
-		assert_matches!(rx.meter().read(), Readout { sent: 4, received: 4, blocked: 0, tof } => {
+		assert_matches!(rx.meter().read(), Readout { sent: 4, received: 4,  channel_len: 0, blocked: 0, tof } => {
 			// every second in test, consumed before
 			assert_eq!(dbg!(tof).len(), 0);
 		});
@@ -68,12 +68,12 @@ fn try_send_try_next_unbounded() {
 		assert_matches!(rx.meter().read(), Readout { sent: 4, received: 1, .. });
 		rx.try_next().unwrap();
 		rx.try_next().unwrap();
-		assert_matches!(tx.meter().read(), Readout { sent: 4, received: 3, blocked: 0, tof } => {
+		assert_matches!(tx.meter().read(), Readout { sent: 4,  channel_len: 1, received: 3, blocked: 0, tof } => {
 			// every second in test, consumed before
 			assert_eq!(dbg!(tof).len(), 1);
 		});
 		rx.try_next().unwrap();
-		assert_matches!(rx.meter().read(), Readout { sent: 4, received: 4, blocked: 0, tof } => {
+		assert_matches!(rx.meter().read(), Readout { sent: 4, channel_len: 0, received: 4, blocked: 0, tof } => {
 			// every second in test, consumed before
 			assert_eq!(dbg!(tof).len(), 0);
 		});

--- a/metered-channel/src/unbounded.rs
+++ b/metered-channel/src/unbounded.rs
@@ -84,7 +84,7 @@ impl<T> Stream for UnboundedMeteredReceiver<T> {
 impl<T> UnboundedMeteredReceiver<T> {
 	fn maybe_meter_tof(&mut self, maybe_value: Option<MaybeTimeOfFlight<T>>) -> Option<T> {
 		self.meter.note_received();
-		let result = maybe_value.map(|value| {
+		maybe_value.map(|value| {
 			match value {
 				MaybeTimeOfFlight::<T>::WithTimeOfFlight(value, tof_start) => {
 					// do not use `.elapsed()` of `std::time`, it may panic
@@ -96,9 +96,7 @@ impl<T> UnboundedMeteredReceiver<T> {
 				MaybeTimeOfFlight::<T>::Bare(value) => value,
 			}
 			.into()
-		});
-
-		result
+		})
 	}
 
 	/// Get an updated accessor object for all metrics collected.

--- a/metered-channel/src/unbounded.rs
+++ b/metered-channel/src/unbounded.rs
@@ -84,7 +84,7 @@ impl<T> Stream for UnboundedMeteredReceiver<T> {
 impl<T> UnboundedMeteredReceiver<T> {
 	fn maybe_meter_tof(&mut self, maybe_value: Option<MaybeTimeOfFlight<T>>) -> Option<T> {
 		self.meter.note_received();
-		maybe_value.map(|value| {
+		let result = maybe_value.map(|value| {
 			match value {
 				MaybeTimeOfFlight::<T>::WithTimeOfFlight(value, tof_start) => {
 					// do not use `.elapsed()` of `std::time`, it may panic
@@ -96,7 +96,12 @@ impl<T> UnboundedMeteredReceiver<T> {
 				MaybeTimeOfFlight::<T>::Bare(value) => value,
 			}
 			.into()
-		})
+		});
+
+		#[cfg(feature = "async_channel")]
+		self.meter.note_channel_len(self.inner.len());
+
+		result
 	}
 
 	/// Get an updated accessor object for all metrics collected.
@@ -170,6 +175,10 @@ impl<T> UnboundedMeteredSender<T> {
 		} else {
 			MaybeTimeOfFlight::Bare(item)
 		};
+
+		#[cfg(feature = "async_channel")]
+		self.meter.note_channel_len(self.inner.len());
+
 		item
 	}
 


### PR DESCRIPTION
Currently we use prometheus query to measure channel size but this is notoriously inaccurate, especially when scrapers are under high load.

For `async_channel`, `len()` is supported, but for `futures_channel` we compute it based on sent/received. 