### PR TITLE
Allow general safe use of `ctx.spawn()` and ability to inject messages via unbounded channel

### DIFF
--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -655,7 +655,7 @@ pub(crate) fn impl_feature_gated_items(
 							#channel_name: #channel_name_tx .clone(),
 						)*
 						#(
-							#channel_name_unbounded: #channel_name_unbounded_tx,
+							#channel_name_unbounded: #channel_name_unbounded_tx .clone(),
 						)*
 					};
 
@@ -694,6 +694,7 @@ pub(crate) fn impl_feature_gated_items(
 
 					let #subsystem_name: OrchestratedSubsystem< #consumes > =	spawn::<_,_, #blocking, _, _, _>(
 							&mut spawner,
+							#channel_name_unbounded_tx,
 							#channel_name_tx,
 							signal_tx,
 							unbounded_meter,
@@ -776,6 +777,7 @@ pub(crate) fn impl_task_kind(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 		#[allow(clippy::too_many_arguments)]
 		pub fn spawn<S, M, TK, Ctx, E, SubSys>(
 			spawner: &mut S,
+			unbounded_message_tx: #support_crate ::metered::UnboundedMeteredSender<MessagePacket<#maybe_boxed_message_generic>>,
 			message_tx: #support_crate ::metered::MeteredSender<MessagePacket<#maybe_boxed_message_generic>>,
 			signal_tx: #support_crate ::metered::MeteredSender< #signal >,
 			// meter for the unbounded channel
@@ -832,6 +834,7 @@ pub(crate) fn impl_task_kind(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 				},
 				tx_signal: signal_tx,
 				tx_bounded: message_tx,
+				tx_unbounded: unbounded_message_tx,
 				signals_received: 0,
 				name,
 			});

--- a/orchestra/proc-macro/src/impl_builder.rs
+++ b/orchestra/proc-macro/src/impl_builder.rs
@@ -710,7 +710,7 @@ pub(crate) fn impl_feature_gated_items(
 
 				use #support_crate ::StreamExt;
 
-				let to_orchestra_rx = to_orchestra_rx.fuse();
+				let to_orchestra_rx = Some(to_orchestra_rx.fuse());
 				let orchestra = #orchestra_name {
 					#(
 						#subsystem_name,

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -175,12 +175,17 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			}
 
 			/// Route a particular message to a subsystem that consumes the message.
-			pub async fn route_message(&mut self, message: #message_wrapper, origin: &'static str) -> ::std::result::Result<(), #error_ty > {
+			pub async fn route_message(&mut self, message: #message_wrapper, origin: &'static str, unbounded: bool) -> ::std::result::Result<(), #error_ty > {
 				match message {
 					#(
 						#feature_gates
-						#message_wrapper :: #consumes_variant ( inner ) =>
-							OrchestratedSubsystem::< #consumes >::send_message2(&mut self. #subsystem_name, inner, origin ).await?,
+						#message_wrapper :: #consumes_variant ( inner ) => {
+							if unbounded {
+								OrchestratedSubsystem::< #consumes >::unbounded_send_message2(&mut self. #subsystem_name, inner, origin ).await?
+							} else {
+								OrchestratedSubsystem::< #consumes >::send_message2(&mut self. #subsystem_name, inner, origin ).await?
+							}
+						}
 					)*
 					// subsystems that are still work in progress
 					#(
@@ -286,6 +291,23 @@ pub(crate) fn impl_orchestrated_subsystem(info: &OrchestraInfo) -> proc_macro2::
 								#support_crate ::OrchestraError::QueueError
 							)),
 					}
+				} else {
+					Ok(())
+				}
+			}
+
+			/// Send a message to the wrapped subsystem.
+			///
+			/// If the inner `instance` is `None`, nothing is happening.
+			pub async fn unbounded_send_message2(&mut self, message: M, origin: &'static str) -> ::std::result::Result<(), #error_ty > {
+				if let Some(ref mut instance) = self.instance {
+					instance.tx_unbounded.unbounded_send(MessagePacket {
+						signals_received: instance.signals_received,
+						message: #maybe_boxed_message,
+					}).map_err(|_| #error_ty :: from(
+								#support_crate ::OrchestraError::QueueError
+							))
+
 				} else {
 					Ok(())
 				}

--- a/orchestra/proc-macro/src/impl_orchestra.rs
+++ b/orchestra/proc-macro/src/impl_orchestra.rs
@@ -91,9 +91,9 @@ pub(crate) fn impl_orchestra_struct(info: &OrchestraInfo) -> proc_macro2::TokenS
 			>,
 
 			/// Gather running subsystems' outbound streams into one.
-			to_orchestra_rx: #support_crate ::stream::Fuse<
+			to_orchestra_rx: Option<#support_crate ::stream::Fuse<
 				#support_crate ::metered::UnboundedMeteredReceiver< #support_crate ::ToOrchestra >
-			>,
+			>>,
 
 			/// Events that are sent to the orchestra from the outside world.
 			events_rx: #support_crate ::metered::MeteredReceiver< #event_ty >,

--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -352,6 +352,8 @@ pub struct SubsystemInstance<Message, Signal> {
 	pub tx_signal: crate::metered::MeteredSender<Signal>,
 	/// Send sink for `Message`s to be sent to a subsystem.
 	pub tx_bounded: crate::metered::MeteredSender<MessagePacket<Message>>,
+	/// Unbounded send sink for `Message`s to be sent to a subsystem.
+	pub tx_unbounded: crate::metered::UnboundedMeteredSender<MessagePacket<Message>>,
 	/// All meters of the particular subsystem instance.
 	pub meters: SubsystemMeters,
 	/// The number of signals already received.


### PR DESCRIPTION
There are 2 changes:
- **Allow `to_orchestra_rx ` to be handled in a `Overseer` task.** 
 Reasoning: the Polkadot overseer handles both events and job spawners in the same select loop. This can create deadlocks in  subsystems that use ctx.spawn() to create a job and wait for it, only if the same subsystem has a full channel and an external messages needs to be passed to it from the overseer select loop.
- **Allow external injection of messages over the unbounded queues of orchestrated subsystems**
Not sure this is the best API to expose this, happy to hear alternatives