### PR TITLE
fix/dotgraph: write dot graph even if conversion to svg fails

### DIFF
--- a/orchestra/proc-macro/tests/assets/sample.dot
+++ b/orchestra/proc-macro/tests/assets/sample.dot
@@ -1,0 +1,14 @@
+digraph {
+				fontname="Cantarell"
+				bgcolor="white"
+				label = "orchestra message flow between subsystems"
+node [colorscheme=rdylgn10]
+    0 [ label="AvailabilityStore"]
+    1 [ label="Provisioner"]
+    2 [ label="RuntimeApi"]
+    3 [ label="ChainApi"]
+    4 [ label="MlExecution"]
+    6 [ label="NetworkBridgeTx"]
+    7 [ color="/rdylgn10/1",fontcolor="/rdylgn10/1",xlabel=<<B><FONT COLOR="/rdylgn10/1">α</FONT></B>>,label="GossipSupport"]
+    1 -> 0 [ label="AvailabilityStoreMessage"]
+}


### PR DESCRIPTION
Due to https://github.com/nadavrot/layout/issues/19 conversion of the dot graph to svg fails, and currently prevents writing both to disk, although the prior would be available.