### PR TITLE
Add priorities support for the bounded metered channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake2"
@@ -121,9 +121,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -160,18 +163,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -387,9 +390,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -668,9 +671,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
@@ -838,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "prioritized-metered-channel"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -944,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
  "bitflags",
  "errno",
@@ -1300,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1315,45 +1318,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/metered-channel/Cargo.toml
+++ b/metered-channel/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "prioritized-metered-channel"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-description = "Channels with built-in observability and message priorizitazion (coming soon™)"
+description = "Channels with built-in observability and optional message priorizitazion"
 repository = "https://github.com/paritytech/orchestra.git"
 license = "MIT OR Apache-2.0"
 

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -363,12 +363,6 @@ impl<T> MeteredReceiver<T> {
 	pub fn len(&self) -> usize {
 		self.meter.calculate_channel_len()
 	}
-
-	#[cfg(feature = "futures_channel")]
-	/// Returns the current number of messages in the channel based on meter approximation
-	pub fn len(&self) -> usize {
-		self.meter.calculate_channel_len()
-	}
 }
 
 impl<T> futures::stream::FusedStream for MeteredReceiver<T> {

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -280,7 +280,7 @@ impl<T> MeteredReceiver<T> {
 	/// Attempt to receive the next item.
 	/// This function returns:
 	///
-	///    Ok(Some(t)) when message is fetched
+	///    `Ok(Some(t))` when message is fetched
 	///    Ok(None) when channel is closed and no messages left in the queue
 	///    Err(e) when there are no messages available, but channel is not yet closed
 	#[cfg(feature = "futures_channel")]

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -278,6 +278,11 @@ impl<T> MeteredReceiver<T> {
 	}
 
 	/// Attempt to receive the next item.
+	/// This function returns:
+	///
+	///    Ok(Some(t)) when message is fetched
+	///    Ok(None) when channel is closed and no messages left in the queue
+	///    Err(e) when there are no messages available, but channel is not yet closed
 	#[cfg(feature = "futures_channel")]
 	pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
 		if let Some(priority_channel) = &mut self.priority_channel {
@@ -294,6 +299,11 @@ impl<T> MeteredReceiver<T> {
 	}
 
 	/// Attempt to receive the next item.
+	/// This function returns:
+	///
+	///    Ok(Some(t)) when message is fetched
+	///    Ok(None) when channel is closed and no messages left in the queue
+	///    Err(e) when there are no messages available, but channel is not yet closed
 	#[cfg(feature = "async_channel")]
 	pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
 		if let Some(priority_channel) = &mut self.priority_channel {

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -533,10 +533,4 @@ impl<T> MeteredSender<T> {
 	pub fn len(&self) -> usize {
 		self.meter.calculate_channel_len()
 	}
-
-	#[cfg(feature = "futures_channel")]
-	/// Returns the current number of messages in the channel based on meter approximation
-	pub fn len(&self) -> usize {
-		self.meter.calculate_channel_len()
-	}
 }

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -32,15 +32,35 @@ use futures::{
 };
 use std::{pin::Pin, result};
 
-use super::{measure_tof_check, CoarseInstant, MaybeTimeOfFlight, Meter};
+use super::{prepare_with_tof, MaybeTimeOfFlight, Meter};
 
-/// Create a wrapped `mpsc::channel` pair of `MeteredSender` and `MeteredReceiver`.
+/// Create a pair of `MeteredSender` and `MeteredReceiver`. No priorities are provided
 pub fn channel<T>(capacity: usize) -> (MeteredSender<T>, MeteredReceiver<T>) {
 	let (tx, rx) = bounded_channel::<MaybeTimeOfFlight<T>>(capacity);
 
 	let shared_meter = Meter::default();
-	let tx = MeteredSender { meter: shared_meter.clone(), inner: tx };
-	let rx = MeteredReceiver { meter: shared_meter, inner: rx };
+	let tx =
+		MeteredSender { meter: shared_meter.clone(), bulk_channel: tx, priority_channel: None };
+	let rx = MeteredReceiver { meter: shared_meter, bulk_channel: rx, priority_channel: None };
+	(tx, rx)
+}
+
+/// Create a pair of `MeteredSender` and `MeteredReceiver`. Priority channel is provided
+pub fn channel_priority<T>(
+	capacity_bulk: usize,
+	capacity_priority: usize,
+) -> (MeteredSender<T>, MeteredReceiver<T>) {
+	let (tx, rx) = bounded_channel::<MaybeTimeOfFlight<T>>(capacity_bulk);
+	let (tx_pri, rx_pri) = bounded_channel::<MaybeTimeOfFlight<T>>(capacity_priority);
+
+	let shared_meter = Meter::default();
+	let tx = MeteredSender {
+		meter: shared_meter.clone(),
+		bulk_channel: tx,
+		priority_channel: Some(tx_pri),
+	};
+	let rx =
+		MeteredReceiver { meter: shared_meter, bulk_channel: rx, priority_channel: Some(rx_pri) };
 	(tx, rx)
 }
 
@@ -49,7 +69,8 @@ pub fn channel<T>(capacity: usize) -> (MeteredSender<T>, MeteredReceiver<T>) {
 pub struct MeteredReceiver<T> {
 	// count currently contained messages
 	meter: Meter,
-	inner: Receiver<MaybeTimeOfFlight<T>>,
+	bulk_channel: Receiver<MaybeTimeOfFlight<T>>,
+	priority_channel: Option<Receiver<MaybeTimeOfFlight<T>>>,
 }
 
 /// A bounded channel error
@@ -196,20 +217,26 @@ impl From<async_channel::RecvError> for RecvError {
 impl<T> std::ops::Deref for MeteredReceiver<T> {
 	type Target = Receiver<MaybeTimeOfFlight<T>>;
 	fn deref(&self) -> &Self::Target {
-		&self.inner
+		&self.bulk_channel
 	}
 }
 
 impl<T> std::ops::DerefMut for MeteredReceiver<T> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.inner
+		&mut self.bulk_channel
 	}
 }
 
 impl<T> Stream for MeteredReceiver<T> {
 	type Item = T;
 	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		match Receiver::poll_next(Pin::new(&mut self.inner), cx) {
+		if let Some(priority_channel) = &mut self.priority_channel {
+			match Receiver::poll_next(Pin::new(priority_channel), cx) {
+				Poll::Ready(maybe_value) => return Poll::Ready(self.maybe_meter_tof(maybe_value)),
+				Poll::Pending => {},
+			}
+		}
+		match Receiver::poll_next(Pin::new(&mut self.bulk_channel), cx) {
 			Poll::Ready(maybe_value) => Poll::Ready(self.maybe_meter_tof(maybe_value)),
 			Poll::Pending => Poll::Pending,
 		}
@@ -217,7 +244,7 @@ impl<T> Stream for MeteredReceiver<T> {
 
 	/// Don't rely on the unreliable size hint.
 	fn size_hint(&self) -> (usize, Option<usize>) {
-		self.inner.size_hint()
+		self.bulk_channel.size_hint()
 	}
 }
 
@@ -253,7 +280,13 @@ impl<T> MeteredReceiver<T> {
 	/// Attempt to receive the next item.
 	#[cfg(feature = "futures_channel")]
 	pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
-		match self.inner.try_next()? {
+		if let Some(priority_channel) = &mut self.priority_channel {
+			match priority_channel.try_next()? {
+				Some(value) => return Ok(self.maybe_meter_tof(Some(value))),
+				None => {},
+			}
+		}
+		match self.bulk_channel.try_next()? {
 			Some(value) => Ok(self.maybe_meter_tof(Some(value))),
 			None => Ok(None),
 		}
@@ -262,42 +295,67 @@ impl<T> MeteredReceiver<T> {
 	/// Attempt to receive the next item.
 	#[cfg(feature = "async_channel")]
 	pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
-		let result = match self.inner.try_recv() {
+		if let Some(priority_channel) = &mut self.priority_channel {
+			match priority_channel.try_recv() {
+				Ok(value) => return Ok(self.maybe_meter_tof(Some(value))),
+				Err(TryRecvError::Empty) => {},
+				Err(err) => return Err(err),
+			}
+		}
+		match self.bulk_channel.try_recv() {
 			Ok(value) => Ok(self.maybe_meter_tof(Some(value))),
 			Err(err) => Err(err),
-		};
-
-		result
+		}
 	}
 
 	/// Receive the next item.
 	#[cfg(feature = "async_channel")]
 	pub async fn recv(&mut self) -> Result<T, RecvError> {
-		let result = match self.inner.recv().await {
+		if let Some(priority_channel) = &mut self.priority_channel {
+			match priority_channel.try_recv() {
+				Ok(value) =>
+					return Ok(self
+						.maybe_meter_tof(Some(value))
+						.expect("wrapped value is always Some, qed")),
+				Err(err) => match err {
+					TryRecvError::Closed => return Err(RecvError {}),
+					TryRecvError::Empty => {}, // We can still have data in the bulk channel
+				},
+			}
+		}
+		match self.bulk_channel.recv().await {
 			Ok(value) =>
 				Ok(self.maybe_meter_tof(Some(value)).expect("wrapped value is always Some, qed")),
 			Err(err) => Err(err.into()),
-		};
-
-		result
+		}
 	}
 
 	/// Attempt to receive the next item without blocking
 	#[cfg(feature = "async_channel")]
 	pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
-		let result = match self.inner.try_recv() {
+		if let Some(priority_channel) = &mut self.priority_channel {
+			match priority_channel.try_recv() {
+				Ok(value) =>
+					return Ok(self
+						.maybe_meter_tof(Some(value))
+						.expect("wrapped value is always Some, qed")),
+				Err(err) => match err {
+					TryRecvError::Closed => return Err(err.into()),
+					TryRecvError::Empty => {},
+				},
+			}
+		}
+		match self.bulk_channel.try_recv() {
 			Ok(value) =>
 				Ok(self.maybe_meter_tof(Some(value)).expect("wrapped value is always Some, qed")),
 			Err(err) => Err(err),
-		};
-
-		result
+		}
 	}
 
 	#[cfg(feature = "async_channel")]
 	/// Returns the current number of messages in the channel
 	pub fn len(&self) -> usize {
-		self.inner.len()
+		self.bulk_channel.len() + self.priority_channel.as_ref().map_or(0, |c| c.len())
 	}
 
 	#[cfg(feature = "futures_channel")]
@@ -309,7 +367,8 @@ impl<T> MeteredReceiver<T> {
 
 impl<T> futures::stream::FusedStream for MeteredReceiver<T> {
 	fn is_terminated(&self) -> bool {
-		self.inner.is_terminated()
+		self.bulk_channel.is_terminated() &&
+			self.priority_channel.as_ref().map_or(true, |c| c.is_terminated())
 	}
 }
 
@@ -318,40 +377,34 @@ impl<T> futures::stream::FusedStream for MeteredReceiver<T> {
 #[derive(Debug)]
 pub struct MeteredSender<T> {
 	meter: Meter,
-	inner: Sender<MaybeTimeOfFlight<T>>,
+	bulk_channel: Sender<MaybeTimeOfFlight<T>>,
+	priority_channel: Option<Sender<MaybeTimeOfFlight<T>>>,
 }
 
 impl<T> Clone for MeteredSender<T> {
 	fn clone(&self) -> Self {
-		Self { meter: self.meter.clone(), inner: self.inner.clone() }
+		Self {
+			meter: self.meter.clone(),
+			bulk_channel: self.bulk_channel.clone(),
+			priority_channel: self.priority_channel.clone(),
+		}
 	}
 }
 
 impl<T> std::ops::Deref for MeteredSender<T> {
 	type Target = Sender<MaybeTimeOfFlight<T>>;
 	fn deref(&self) -> &Self::Target {
-		&self.inner
+		&self.bulk_channel
 	}
 }
 
 impl<T> std::ops::DerefMut for MeteredSender<T> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.inner
+		&mut self.bulk_channel
 	}
 }
 
 impl<T> MeteredSender<T> {
-	fn prepare_with_tof(&self, item: T) -> MaybeTimeOfFlight<T> {
-		let previous = self.meter.note_sent();
-		let item = if measure_tof_check(previous) {
-			MaybeTimeOfFlight::WithTimeOfFlight(item, CoarseInstant::now())
-		} else {
-			MaybeTimeOfFlight::Bare(item)
-		};
-
-		item
-	}
-
 	/// Get an updated accessor object for all metrics collected.
 	pub fn meter(&self) -> &Meter {
 		// For async_channel we can update channel length in the meter access
@@ -387,7 +440,7 @@ impl<T> MeteredSender<T> {
 		&mut self,
 		msg: MaybeTimeOfFlight<T>,
 	) -> result::Result<(), SendError<T>> {
-		let fut = self.inner.send(msg);
+		let fut = self.bulk_channel.send(msg);
 		futures::pin_mut!(fut);
 		let result = fut.await.map_err(|err| {
 			self.meter.retract_sent();
@@ -402,7 +455,7 @@ impl<T> MeteredSender<T> {
 		&mut self,
 		msg: MaybeTimeOfFlight<T>,
 	) -> result::Result<(), SendError<T>> {
-		let fut = self.inner.send(msg);
+		let fut = self.bulk_channel.send(msg);
 		futures::pin_mut!(fut);
 		fut.await.map_err(|_| {
 			self.meter.retract_sent();
@@ -415,8 +468,8 @@ impl<T> MeteredSender<T> {
 	#[cfg(feature = "futures_channel")]
 	/// Attempt to send message or fail immediately.
 	pub fn try_send(&mut self, msg: T) -> result::Result<(), TrySendError<T>> {
-		let msg = self.prepare_with_tof(msg); // note_sent is called in here
-		self.inner.try_send(msg).map_err(|e| {
+		let msg = prepare_with_tof(&self.meter, msg); // note_sent is called in here
+		self.bulk_channel.try_send(msg).map_err(|e| {
 			self.meter.retract_sent(); // we didn't send it, so we need to undo the note_send
 			TrySendError::from(e)
 		})
@@ -425,19 +478,17 @@ impl<T> MeteredSender<T> {
 	#[cfg(feature = "async_channel")]
 	/// Attempt to send message or fail immediately.
 	pub fn try_send(&mut self, msg: T) -> result::Result<(), TrySendError<T>> {
-		let msg = self.prepare_with_tof(msg); // note_sent is called in here
-		let result = self.inner.try_send(msg).map_err(|e| {
+		let msg = prepare_with_tof(&self.meter, msg); // note_sent is called in here
+		self.bulk_channel.try_send(msg).map_err(|e| {
 			self.meter.retract_sent(); // we didn't send it, so we need to undo the note_send
 			TrySendError::from(e)
-		});
-
-		result
+		})
 	}
 
 	#[cfg(feature = "async_channel")]
 	/// Returns the current number of messages in the channel
 	pub fn len(&self) -> usize {
-		self.inner.len()
+		self.bulk_channel.len() + self.priority_channel.as_ref().map_or(0, |c| c.len())
 	}
 
 	#[cfg(feature = "futures_channel")]

--- a/metered-channel/src/bounded.rs
+++ b/metered-channel/src/bounded.rs
@@ -46,7 +46,7 @@ pub fn channel<T>(capacity: usize) -> (MeteredSender<T>, MeteredReceiver<T>) {
 }
 
 /// Create a pair of `MeteredSender` and `MeteredReceiver`. Priority channel is provided
-pub fn channel_priority<T>(
+pub fn channel_with_priority<T>(
 	capacity_bulk: usize,
 	capacity_priority: usize,
 ) -> (MeteredSender<T>, MeteredReceiver<T>) {

--- a/metered-channel/src/tests.rs
+++ b/metered-channel/src/tests.rs
@@ -190,7 +190,7 @@ fn blocked_send_is_metered() {
 				assert!(locked_sender.lock().unwrap().send(msg1()).await.is_ok());
 				assert!(locked_sender.lock().unwrap().send(msg1()).await.is_ok());
 				// We should be able to do that even if a channel is not configured as priority
-				assert!(locked_sender.lock().unwrap().send_priority(msg2()).await.is_ok());
+				assert!(locked_sender.lock().unwrap().priority_send(msg2()).await.is_ok());
 			},
 			async move {
 				bounded_receiver.next().await.unwrap();
@@ -228,7 +228,7 @@ fn send_try_next_priority() {
 		tx.try_send(msg).unwrap();
 		assert_matches!(tx.meter().read(), Readout { sent: 4, received: 0, .. });
 		assert!(tx.try_send(msg).is_err()); // Reached capacity
-		tx.try_send_priority(msg_pri).unwrap();
+		tx.try_priority_send(msg_pri).unwrap();
 		assert_matches!(tx.meter().read(), Readout { sent: 5, received: 0, .. });
 		let res = rx.try_next().unwrap().unwrap();
 		assert_matches!(rx.meter().read(), Readout { sent: 5, received: 1, .. });

--- a/metered-channel/src/tests.rs
+++ b/metered-channel/src/tests.rs
@@ -208,9 +208,9 @@ fn blocked_send_is_metered() {
 fn send_try_next_priority() {
 	block_on(async move {
 		#[cfg(feature = "async_channel")]
-		let (mut tx, mut rx) = channel_priority::<Msg>(4, 1);
+		let (mut tx, mut rx) = channel_with_priority::<Msg>(4, 1);
 		#[cfg(feature = "futures_channel")]
-		let (mut tx, mut rx) = channel_priority::<Msg>(3, 1);
+		let (mut tx, mut rx) = channel_with_priority::<Msg>(3, 1);
 
 		let msg = msg1();
 		let msg_pri = msg2();

--- a/metered-channel/src/tests.rs
+++ b/metered-channel/src/tests.rs
@@ -207,7 +207,11 @@ fn blocked_send_is_metered() {
 #[test]
 fn send_try_next_priority() {
 	block_on(async move {
+		#[cfg(feature = "async_channel")]
 		let (mut tx, mut rx) = channel_priority::<Msg>(4, 1);
+		#[cfg(feature = "futures_channel")]
+		let (mut tx, mut rx) = channel_priority::<Msg>(3, 1);
+
 		let msg = msg1();
 		let msg_pri = msg2();
 		assert_matches!(rx.meter().read(), Readout { sent: 0, received: 0, .. });

--- a/orchestra/Cargo.toml
+++ b/orchestra/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1.35"
 futures = "0.3"
 async-trait = "0.1"
 thiserror = "1"
-metered = { package = "prioritized-metered-channel", version = "0.5.0", path = "../metered-channel", default-features = false }
+metered = { package = "prioritized-metered-channel", version = "0.6.0", path = "../metered-channel", default-features = false }
 orchestra-proc-macro = { version = "0.3.0", path = "./proc-macro" }
 futures-timer = "3.0.2"
 pin-project = "1.0"


### PR DESCRIPTION
This PR adds `_priority` set of methods to send messages over channels with higher priority.

TODO: document the logic and add proc-macro support to the orchestra