### PR TITLE
fixup! Implement separate signal and message flows (#66)

### DIFF
--- a/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
+++ b/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
@@ -498,7 +498,7 @@ pub(crate) fn impl_subsystem_context_trait_for(
 				let result = self.signals.next().await.ok_or(#support_crate ::OrchestraError::Context(
 					"Signal channel is terminated and empty.".to_owned(),
 				).into());
-				if let Ok(_) = result {
+				if result.is_ok() {
 					self.signals_received.inc();
 				}
 				result

--- a/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
+++ b/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
@@ -495,9 +495,13 @@ pub(crate) fn impl_subsystem_context_trait_for(
 			}
 
 			async fn recv_signal(&mut self) -> ::std::result::Result<#signal, #error_ty> {
-				self.signals.next().await.ok_or(#support_crate ::OrchestraError::Context(
+				let result = self.signals.next().await.ok_or(#support_crate ::OrchestraError::Context(
 					"Signal channel is terminated and empty.".to_owned(),
-				).into())
+				).into());
+				if let Ok(_) = result {
+					self.signals_received.inc();
+				}
+				result
 			}
 
 			fn sender(&mut self) -> &mut Self::Sender {


### PR DESCRIPTION
We forgot to increment signals_received, that make subsystems to fall out of sync if they start using recv_signal, which we did in https://github.com/paritytech/polkadot-sdk/pull/2125 and that made roco to slow-down significantly.