### PR TITLE
Bump `proc-macro-crate` to v 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,11 +1012,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "once_cell",
  "toml_edit",
 ]
 
@@ -1307,15 +1306,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",

--- a/orchestra/proc-macro/Cargo.toml
+++ b/orchestra/proc-macro/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 syn = { version = "1.0.109", features = ["full", "extra-traits"] }
 quote = "1.0.20"
 proc-macro2 = { version = "1.0.47", features = ["span-locations"] }
-proc-macro-crate = "1.1.3"
+proc-macro-crate = "3.1.0"
 expander = { version = "2.0.0", default-features = false }
 petgraph = "0.6.0"
 itertools = { version = "0.11" }


### PR DESCRIPTION
Needed for https://github.com/paritytech/polkadot-sdk/pull/4409