### PR TITLE
Update locked expander version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,9 +465,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "expander"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
+checksum = "00e83c02035136f1592a47964ea60c05a50e4ed8b5892cfac197063850898d4d"
 dependencies = [
  "blake2",
  "fs-err",


### PR DESCRIPTION
Expander was bumped in https://github.com/paritytech/orchestra/pull/74, but locked version wasn't updated