### PR TITLE
Fix using unimported priority structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "orchestra"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "criterion",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "orchestra"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.3.8"
+version = "0.4.0"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paritytech/orchestra"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.3.7"
+version = "0.3.8"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paritytech/orchestra"

--- a/orchestra/Cargo.toml
+++ b/orchestra/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 async-trait = "0.1"
 thiserror = "1"
 metered = { package = "prioritized-metered-channel", version = "0.6.1", path = "../metered-channel", default-features = false }
-orchestra-proc-macro = { version = "0.3.8", path = "./proc-macro" }
+orchestra-proc-macro = { version = "0.4.0", path = "./proc-macro" }
 futures-timer = "3.0.2"
 pin-project = "1.0"
 dyn-clonable = "0.9"

--- a/orchestra/Cargo.toml
+++ b/orchestra/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 async-trait = "0.1"
 thiserror = "1"
 metered = { package = "prioritized-metered-channel", version = "0.6.1", path = "../metered-channel", default-features = false }
-orchestra-proc-macro = { version = "0.3.5", path = "./proc-macro" }
+orchestra-proc-macro = { version = "0.3.8", path = "./proc-macro" }
 futures-timer = "3.0.2"
 pin-project = "1.0"
 dyn-clonable = "0.9"

--- a/orchestra/proc-macro/src/impl_channels_out.rs
+++ b/orchestra/proc-macro/src/impl_channels_out.rs
@@ -77,7 +77,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 		// when no defined messages in enum
 		impl ChannelsOut {
 			/// Send a message via a bounded channel.
-			pub async fn send_and_log_error<P: Priority>(
+			pub async fn send_and_log_error<P: #support_crate ::Priority>(
 				&mut self,
 				signals_received: usize,
 				message: #message_wrapper
@@ -87,12 +87,12 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 					#feature_gates
 					#message_wrapper :: #consumes_variant ( inner ) => {
 						match P::priority() {
-							PriorityLevel::Normal => {
+							#support_crate ::PriorityLevel::Normal => {
 								self. #channel_name .send(
 									#support_crate ::make_packet(signals_received, #maybe_boxed_send)
 								).await
 							},
-							PriorityLevel::High => {
+							#support_crate ::PriorityLevel::High => {
 								self. #channel_name .priority_send(
 									#support_crate ::make_packet(signals_received, #maybe_boxed_send)
 								).await
@@ -125,7 +125,7 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 			}
 
 			/// Try to send a message via a bounded channel.
-			pub fn try_send<P: Priority>(
+			pub fn try_send<P: #support_crate ::Priority>(
 				&mut self,
 				signals_received: usize,
 				message: #message_wrapper,
@@ -135,12 +135,12 @@ pub(crate) fn impl_channels_out_struct(info: &OrchestraInfo) -> Result<proc_macr
 					#feature_gates
 					#message_wrapper :: #consumes_variant ( inner ) => {
 						match P::priority() {
-							PriorityLevel::Normal => {
+							#support_crate ::PriorityLevel::Normal => {
 								self. #channel_name .try_send(
 									#support_crate ::make_packet(signals_received, #maybe_boxed_send)
 								)
 							},
-							PriorityLevel::High => {
+							#support_crate ::PriorityLevel::High => {
 								self. #channel_name .try_priority_send(
 									#support_crate ::make_packet(signals_received, #maybe_boxed_send)
 								)

--- a/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
+++ b/orchestra/proc-macro/src/impl_subsystem_ctx_sender.rs
@@ -278,10 +278,10 @@ pub(crate) fn impl_subsystem_sender(
 			{
 				async fn send_message(&mut self, msg: OutgoingMessage)
 				{
-					self.send_message_with_priority::<NormalPriority>(msg).await;
+					self.send_message_with_priority::<#support_crate ::NormalPriority>(msg).await;
 				}
 
-				async fn send_message_with_priority<P: Priority>(&mut self, msg: OutgoingMessage)
+				async fn send_message_with_priority<P: #support_crate ::Priority>(&mut self, msg: OutgoingMessage)
 				{
 					self.channels.send_and_log_error::<P>(
 						self.signals_received.load(),
@@ -293,10 +293,10 @@ pub(crate) fn impl_subsystem_sender(
 
 				fn try_send_message(&mut self, msg: OutgoingMessage) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<OutgoingMessage>>
 				{
-					self.try_send_message_with_priority::<NormalPriority>(msg)
+					self.try_send_message_with_priority::<#support_crate ::NormalPriority>(msg)
 				}
 
-				fn try_send_message_with_priority<P: Priority>(&mut self, msg: OutgoingMessage) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<OutgoingMessage>>
+				fn try_send_message_with_priority<P: #support_crate ::Priority>(&mut self, msg: OutgoingMessage) -> ::std::result::Result<(), #support_crate ::metered::TrySendError<OutgoingMessage>>
 				{
 					self.channels.try_send::<P>(
 						self.signals_received.load(),


### PR DESCRIPTION
Fixes https://github.com/paritytech/orchestra/issues/80

v0.3.7 requires importing of priority related structs what conflicts with the definition of a *patch* version 

In this PR priority related structs prefixed with `#support_crate ::` that points to otchestra so it doesn't require the explicit import to use `#[subsystem]`. 

However if the `Sender` trait is used it still requires to implement new methods `send_message_with_priority` and `try_send_message_with_priority`. This PR https://github.com/paritytech/polkadot-sdk/pull/4763/ shows required changes.

So I suggest bumping the library to v0.4.0. v0.3.7 should be yanked.
