### PR TITLE
make it possible to route messages based on priority

### DIFF
--- a/orchestra/src/lib.rs
+++ b/orchestra/src/lib.rs
@@ -496,6 +496,8 @@ where
 
 /// Priority of messages sending to the individual subsystems.
 /// Only for the bounded channel sender.
+
+#[derive(Debug)]
 pub enum PriorityLevel {
 	/// Normal priority.
 	Normal,


### PR DESCRIPTION
Extend round_message to be able to route messages based on the priority of the message, this will be used in the overseer to send messages with high priority for https://github.com/paritytech/polkadot-sdk/issues/8830.